### PR TITLE
[feat]: Rest API 문서화를 위한 Swagger 3.0 프레임워크 추가 (#2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.0.2'
+	id 'org.springframework.boot' version '2.7.9'
 	id 'io.spring.dependency-management' version '1.1.0'
 }
 
@@ -15,10 +15,14 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	// https://mvnrepository.com/artifact/mysql/mysql-connector-java
 	implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.30'
+
+	// Swagger3
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sinabro/server/config/SwaggerConfig.java
+++ b/src/main/java/com/sinabro/server/config/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.sinabro.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30)
+                .useDefaultResponseMessages(false)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.sinabro.server.controller"))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo());
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Sinabro_API")
+                .description("Sinabro_API_DESCRIPTION")
+                .version("1.0.0")
+                .build();
+    }
+}

--- a/src/main/java/com/sinabro/server/controller/PlacesController.java
+++ b/src/main/java/com/sinabro/server/controller/PlacesController.java
@@ -2,24 +2,27 @@ package com.sinabro.server.controller;
 
 import com.sinabro.server.model.places.Places;
 import com.sinabro.server.model.places.PlacesDAO;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
+@Api(tags = {"장소 API"})
 public class PlacesController {
+
     @Autowired
     private PlacesDAO placesDAO;
     @GetMapping("/api/places")
+    @ApiOperation(value = "등록된 모든 장소 정보 조회", notes = "사용자에 의해 등록된 모든 장소의 정보를 조회합니다.", responseContainer = "List")
     public List<Places> getAllPlaces() {
         return placesDAO.getAllPlaces();
     }
 
     @PostMapping("/api/places/save")
+    @ApiOperation(value = "장소 등록", notes = "마커 위치에 대한 장소 정보를 등록합니다.", responseContainer = "List")
     public Places save(@RequestBody Places place) {
         return placesDAO.save(place);
     }

--- a/src/main/java/com/sinabro/server/model/places/Places.java
+++ b/src/main/java/com/sinabro/server/model/places/Places.java
@@ -1,10 +1,9 @@
 package com.sinabro.server.model.places;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import org.springframework.data.geo.Point;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Entity
 public class Places {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,5 +11,8 @@ spring:
     hibernates:
       ddl-auto: update
     show-sql: 'true'
+  mvc:
+    pathmatch:
+      matching-strategy: ant-path-matcher
 server:
   port: '9000'


### PR DESCRIPTION
## 👀 이슈

resolve #2 

## 📌 개요

앞으로 추가될 API들을 Swagger를 통해 문서화하여 보다 관리하기
용이하도록 해당 프레임워크를 추가하였습니다.

## 👩‍💻 작업 사항

- 서버 내 Swagger 적용
- Swagger-ui 페이지 내에서 기존 `장소 관련 API` 스펙을 확인할 수 있도록
일부 annotation을 추가하였습니다.

## ✅ 참고 사항

> 로컬 환경 swagger-ui 주소 : **http://localhost:9000/swagger-ui/index.html**

- `Swagger3.0` 추가 후

<img width="1321" alt="Screenshot 2023-03-19 at 12 49 57 PM" src="https://user-images.githubusercontent.com/56868605/226152536-4e99cf50-89fe-4abf-8a90-80ad02692f86.png">
<img width="1315" alt="Screenshot 2023-03-19 at 12 50 07 PM" src="https://user-images.githubusercontent.com/56868605/226152543-942f515c-5251-4917-8d35-cc457df6cb01.png">