### PR TITLE
[fix]: MySQL 포트포워딩으로 인한 Hostname/Port 값 변경 (#6)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,18 @@
 spring:
   datasource:
     username: user
-    url: jdbc:mysql://52.78.11.161:58448/sinabro?createDatabaseIfNotExist=true
+    url: jdbc:mysql://3.35.20.238:50514/sinabro?createDatabaseIfNotExist=true
     password: user012
   jpa:
-    generate-ddl: 'true'
+    generate-ddl: "true"
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
     hibernates:
       ddl-auto: update
-    show-sql: 'true'
+    show-sql: "true"
   mvc:
     pathmatch:
       matching-strategy: ant-path-matcher
 server:
-  port: '9000'
+  port: "9000"


### PR DESCRIPTION
## 👀 이슈

resolve #6 

## 📌 개요

기존 `goormIDE`에서 서비스 중이던 MySQL의 포트포워딩 정보가
변경되어 서버와의 상호 통신 에러가 발생해 변경된 Hostname 및 Port값으로
수정하고자 하였습니다.

## 👩‍💻 작업 사항

- `application.yml` 파일 내 MySQL url 수정

## ✅ 참고 사항

- 현재 `application.yml` 파일이 깃 이력에 포함되어 있는데, DB 접근에 대한 보안 이슈가
발생할 수도 있을 것 같아 추후에 배포 전용 브랜치를 마련하도록 하겠습니다.
