### PR TITLE
[feat]: '장소 정보' 및 '인원수 정보' 관련 APIs 로직 수정 및 신규 추가 (#15)

### DIFF
--- a/models/people_number.js
+++ b/models/people_number.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const peopleNumberSchema = new Schema(
+  {
+    placeId: { type: Schema.Types.ObjectId, ref: 'places' },
+    peopleCount: Number,
+    createdTime: String,
+  },
+  {
+    versionKey: false,
+  }
+);
+
+const PeopleNumber = mongoose.model('people_number', peopleNumberSchema);
+
+module.exports = PeopleNumber;

--- a/models/place.js
+++ b/models/place.js
@@ -1,9 +1,10 @@
 const mongoose = require('mongoose');
 
-const PlaceSchema = new mongoose.Schema(
+const placeSchema = new mongoose.Schema(
   {
     placeName: String,
     address: String,
+    detailAddress: String,
     latitude: String,
     longitude: String,
   },
@@ -12,6 +13,6 @@ const PlaceSchema = new mongoose.Schema(
   }
 );
 
-const Place = mongoose.model('Place', PlaceSchema);
+const Place = mongoose.model('places', placeSchema);
 
 module.exports = Place;

--- a/routes/people_numbers.js
+++ b/routes/people_numbers.js
@@ -1,0 +1,90 @@
+const express = require('express');
+const PeopleNumber = require('../models/people_number');
+const { getFormattedDate } = require('../utils/dateUtils');
+const router = express.Router();
+
+// people_numbers collection 내 모든 document 데이터(들) 반환(Array)
+router.get('/', async (req, res) => {
+  try {
+    const placeInfos = await PeopleNumber.find();
+    if (!placeInfos) {
+      return res.status(404).json({ message: 'Item not found.' });
+    }
+
+    res.status(200).json(placeInfos);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// people_numbers와 places collection의 참조 document 데이터(들) 반환(Array)
+router.get('/placeInformations', async (req, res) => {
+  try {
+    const placeInformations = await PeopleNumber.find()
+      .populate('placeId')
+      .exec();
+    if (!placeInformations) {
+      return res.status(404).json({ message: 'Item not found.' });
+    }
+
+    // PlaceId 별로 데이터를 그룹화
+    const placeIdGroups = {};
+    for (const info of placeInformations) {
+      const placeIdStr = info.placeId._id.toString();
+      if (!placeIdGroups[placeIdStr]) {
+        placeIdGroups[placeIdStr] = [];
+      }
+      placeIdGroups[placeIdStr].push(info);
+    }
+
+    // 현재 일자를 가져옴
+    const currentTime = new Date();
+
+    // 각 그룹에 대해 updateElapsedTime 계산
+    let updatedPlaceInformations = [];
+    for (const placeIdStr in placeIdGroups) {
+      const group = placeIdGroups[placeIdStr];
+      group.sort((a, b) => new Date(a.createdTime) - new Date(b.createdTime)); // 정렬: 최신 일자가 뒤로
+
+      const elapsedTime =
+        group.length > 1
+          ? Math.floor(
+              (currentTime - new Date(group[group.length - 1].createdTime)) /
+                1000
+            )
+          : -1;
+
+      for (const info of group) {
+        let updatedInfo = info.toObject();
+        updatedInfo.updateElapsedTime = elapsedTime;
+        updatedPlaceInformations.push(updatedInfo);
+      }
+    }
+
+    res.status(200).json(updatedPlaceInformations);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// 특정 장소에 대한 (인원수 정보)를 DB에 추가
+router.post('/', async (req, res) => {
+  if (!req.body.placeId || !req.body.peopleCount) {
+    return res.status(400).json({ message: 'Missing required field.' });
+  }
+
+  const peopleNumber = new PeopleNumber({
+    placeId: req.body.placeId,
+    peopleCount: req.body.peopleCount,
+    createdTime: getFormattedDate,
+  });
+
+  try {
+    const newPeopleNumber = await peopleNumber.save();
+    res.status(201).json(newPeopleNumber);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/routes/places.js
+++ b/routes/places.js
@@ -1,33 +1,104 @@
 const express = require('express');
 const Place = require('../models/place');
+const PeopleNumber = require('../models/people_number');
+const { getFormattedDate } = require('../utils/dateUtils');
 const router = express.Router();
 
+// :id값에 따른 document 중 _id값이 :id와 동일한 document 설정 및 조회
+const getPlace = async (req, res, next) => {
+  let place;
+  try {
+    place = await Place.findById(req.params.id);
+    if (!place) {
+      return res.status(404).json({ message: 'Cannot find place' });
+    }
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+
+  res.place = place;
+  next();
+};
+
+// places collection 내 모든 document 데이터(들) 반환(Array)
 router.get('/', async (req, res) => {
   try {
     const places = await Place.find();
+    if (!places) {
+      res.status(404).json({ message: 'Item not found.' });
+      return;
+    }
     res.json(places);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }
 });
 
+// :id값과 _id 필드의 값이 동일한 document의 데이터를 res.place로 설정 및 조회
+router.get('/:id', getPlace, async (req, res) => {
+  res.send(res.place);
+});
+
+// (장소 정보, places[collection])와 해당 장소의 (인원수 정보, people-numbers[collection])를 DB에 추가
 router.post('/', async (req, res) => {
+  if (
+    !req.body.placeName ||
+    !req.body.address ||
+    !req.body.detailAddress ||
+    !req.body.latitude ||
+    !req.body.longitude
+  ) {
+    return res.status(400).json({ message: 'Missing required field.' });
+  }
+
   const place = new Place({
     placeName: req.body.placeName,
     address: req.body.address,
+    detailAddress: req.body.detailAddress,
     latitude: req.body.latitude,
     longitude: req.body.longitude,
   });
+
   try {
     const newPlace = await place.save();
-    res.status(201).json(newPlace);
+    const peopleNumber = new PeopleNumber({
+      placeId: newPlace._id,
+      peopleCount: -1,
+      createdTime: getFormattedDate,
+    });
+    const newPeopleNumber = await peopleNumber.save();
+
+    res.status(201).json({ newPlace, newPeopleNumber });
   } catch (err) {
     res.status(400).json({ message: err.message });
   }
 });
 
-router.patch('/', (req, res) => {});
+// :id값과 _id 필드의 값이 동일한 document의 placeName, detailAddress 데이터 수정
+router.patch('/:id', getPlace, async (req, res) => {
+  if (req.body.placeName != null) res.place.placeName = req.body.placeName;
+  if (req.body.detailAddress != null)
+    res.place.detailAddress = req.body.detailAddress;
+  try {
+    const updatedPlace = await res.place.save();
+    res.status(200).json(updatedPlace);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
 
-router.delete('/', (req, res) => {});
+// :id값과 _id 필드의 값이 동일한 (people_number) 및 (places) collection 내 document(들) 삭제
+router.delete('/:id', getPlace, async (req, res) => {
+  try {
+    // people_numbers collection 내 삭제하려는 장소의 _id값을 지닌 연관 document(들) 일괄 제거
+    await PeopleNumber.deleteMany({ placeId: res.place._id });
+    await res.place.deleteOne();
+    res.status(204).json({
+      message: 'Deleted (Place information) and (People number info)',
+    });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -19,8 +19,13 @@ app.get('/', (req, res) => {
 
 app.use(express.json());
 
+// [places] collection에 대한 router 등록
 const placeRouter = require('./routes/places');
 app.use('/places', placeRouter);
+
+// [people_numbers] collection에 대한 router 등록
+const peopleNumberRouter = require('./routes/people_numbers');
+app.use('/peopleNumbers', peopleNumberRouter);
 
 app.listen(port, () => {
   console.log('Server Started');

--- a/utils/dateUtils.js
+++ b/utils/dateUtils.js
@@ -1,0 +1,28 @@
+exports.getFormattedDate = function () {
+  const date = new Date();
+
+  const year = date.getFullYear();
+  const month = ('0' + (date.getMonth() + 1)).slice(-2);
+  const day = ('0' + date.getDate()).slice(-2);
+
+  const hours = ('0' + date.getHours()).slice(-2);
+  const minutes = ('0' + date.getMinutes()).slice(-2);
+  const seconds = ('0' + date.getSeconds()).slice(-2);
+  const milliseconds = ('00' + date.getMilliseconds()).slice(-3);
+
+  return (
+    year +
+    '-' +
+    month +
+    '-' +
+    day +
+    ' ' +
+    hours +
+    ':' +
+    minutes +
+    ':' +
+    seconds +
+    '.' +
+    milliseconds
+  );
+};


### PR DESCRIPTION
## 👀 이슈

resolve #15 

## 📌 개요

기존 `장소 정보`를 나타내는 데 누락된 필드(`상세 주소`)가 존재하였고, 해당 장소에 대한
`인원수 정보`를 함께 포함할 수 있도록 `people_numbers` collection 추가에 따른 model
파일 추가 및 관련 API 로직들을 추가하였습니다.

## 👩‍💻 작업 사항

- `places` collection에 대한 model 파일 내 **`detailAddress`** 필드 추가
- `people_numbers` collection에 대한 신규 model 파일 추가
> **⚙️ 필드 구성**
> (1) placeId(`ObjectId`: ref `places` collection)
> (2) peopleCount(`Number`)
> (3) createdTime(`String`)
<br />

> **Note** (`places` collection 관련 APIs)
- _**[GET]**_ **`/places`** API 수정 **➔** _HTTP Method_ **`404(Cannot not find the data)`** 에 대한 로직 추가
- _**[GET]**_ **`/places/:id`** API 추가 **➔** :id값과 _id 필드의 값이 동일한 document의 데이터를 res.place로 설정 및 조회 )
- _**[POST]**_ **`/places`** API 추가 **➔** (장소 정보, places[collection])와 해당 장소의 (인원수 정보, people-numbers[collection])를 DB에 추가 )
- _**[PATCH]**_ **`/places/:id`** API 추가 **➔** :id값과 _id 필드의 값이 동일한 document의 placeName, detailAddress 데이터 수정
- _**[DELETE]**_ **`/places/:id`** API 추가 **➔** :id값과 _id 필드의 값이 동일한 (people_number) 및 (places) collection 내 document(들) 삭제
<br />

> **Note** (`people_numbers` collection 관련 APIs)
- _**[GET]**_ **`/peopleNumbers`** API 추가 **➔** people_numbers collection 내 모든 document 데이터(들) 반환(Array)
- _**[GET]**_ **`/peopleNumbers/placeInformations`** API 추가 **➔** people_numbers와 places collection의 참조 document 데이터(들) 반환(Array)로 설정 및 조회 )
- _**[POST]**_ **`/peopleNumbers`** API 추가 **➔** 특정 장소에 대한 (인원수 정보)를 DB에 추가numbers[collection])를 DB에 추가 )

## ✅ 참고 사항

없습니다