### PR TITLE
[fix]: 장소 정보 삭제 API response http status code 및 장소 정보 등록 API response body 데이터 변경 (#24)

### DIFF
--- a/routes/places.js
+++ b/routes/places.js
@@ -214,7 +214,7 @@ router.post('/', async (req, res) => {
     });
 
     const newPeopleNumber = await peopleNumber.save();
-    res.status(201).json({ newMarker, newPlace, newPeopleNumber });
+    res.status(201).json(newPlace);
   } catch (err) {
     res.status(400).json({ message: err.message });
   }
@@ -287,7 +287,7 @@ router.patch('/:id', getPlace, async (req, res) => {
  *         required: true
  *         description: placeId
  *     responses:
- *       '204':
+ *       '200':
  *         description: Created
  *         schema:
  *           type: integer
@@ -317,7 +317,7 @@ router.delete('/:id', getPlace, async (req, res) => {
     // people_numbers collection 내 삭제하려는 장소의 _id값을 지닌 연관 document(들) 일괄 제거
     await PeopleNumber.deleteMany({ placeId: res.place._id });
     await res.place.deleteOne();
-    res.status(204).json(places.length - 1);
+    res.status(200).json(places.length - 1);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }


### PR DESCRIPTION
## 👀 이슈

resolve #24 

## 📌 개요

기존 `장소 정보 삭제` API 요청 시 응답으로 동일한 위치에 해당하는
장소에 대하여 잔여 장소의 수를 `response body`로 client 측에 응답해
주게 되는데, 이때 `http status code`를 `204`로 응답하였을 경우
`response body`에 담긴 데이터는 누락되는 문제가 있어 `200`으로 값을
수정하였고, `장소 정보 등록` API 요청 후 `place` object에 대한 값만
body로 보내어 client 측과 데이터 규격을 맞출 수 있도록 코드를 수정하였습니다.

## 👩‍💻 작업 사항

- `장소 정보 삭제` API response `http status code` 변경
> `http status code` 변경으로 인한 `swagger` 문서 수정
- `장소 정보 등록` API `response body` 데이터 변경

## ✅ 참고 사항

없습니다
