### PR TITLE
[fix]: `JWT` 도입으로 인한 기존 APIs 사용 전 토큰 유효성 인증이 필요 부분들에 대한 검증 단계 추가 (#28)

### DIFF
--- a/routes/middlewares/authorization.js
+++ b/routes/middlewares/authorization.js
@@ -3,7 +3,6 @@ require('dotenv').config();
 
 const verifyToken = (req, res, next) => {
   try {
-    console.log(req.headers.cookie.replace('user=', ''));
     const clientToken = req.headers.cookie.replace('user=', '');
     const decoded = jwt.verify(clientToken, process.env.JWT_TOKEN_SECRET);
     if (!decoded) {

--- a/routes/people_numbers.js
+++ b/routes/people_numbers.js
@@ -80,7 +80,7 @@ router.get('/', async (req, res) => {
  * [앱 내 사용 여부 ✅]
  * places와 marker collection의 참조 document 데이터(들) 반환(Array)
  */
-router.get('/placeInformations', async (req, res) => {
+router.get('/public/placeInformations', async (req, res) => {
   try {
     const placeInformations = await PeopleNumber.find()
       .populate({
@@ -117,7 +117,7 @@ router.get('/:id', getPlaceInformations, async (req, res) => {
  * :id값과 markerId 필드의 값이 동일한 document에 대해서
  * places와 marker collection의 참조 document 데이터(들) 반환(Array)
  */
-router.get('/:id/placeInformations', async (req, res) => {
+router.get('/public/:id/placeInformations', async (req, res) => {
   try {
     const placeInformations = await PeopleNumber.find()
       .populate({
@@ -128,6 +128,9 @@ router.get('/:id/placeInformations', async (req, res) => {
     if (!placeInformations) {
       return res.status(404).json({ message: 'Item not found.' });
     }
+
+    console.log(placeInformations[0].placeId.markerId._id.toString());
+    console.log(req.params.id);
 
     const filteredPlaceInformations = placeInformations.filter(
       (info) => info.placeId.markerId._id.toString() === req.params.id
@@ -147,16 +150,13 @@ router.get('/:id/placeInformations', async (req, res) => {
  * [앱 내 사용 여부 ✅]
  * 특정 장소에 대한 (인원수 정보)를 DB에 추가
  */
-router.post('/', async (req, res) => {
+router.post('/private', async (req, res) => {
   if (!req.body.placeId || !req.body.peopleCount) {
     return res.status(400).json({ message: 'Missing required field.' });
   }
 
-  const peopleNumber = new PeopleNumber({
-    placeId: req.body.placeId,
-    peopleCount: req.body.peopleCount,
-    createdTime: getFormattedDate(),
-  });
+  const peopleNumber = new PeopleNumber(req.body);
+  peopleNumber.createdTime = getFormattedDate();
 
   try {
     const newPeopleNumber = await peopleNumber.save();


### PR DESCRIPTION
## 👀 이슈

resolve #28 

## 📌 개요

#26 이슈 작업을 통해 현재 서버 측에서 다양한 APIs를 사용할 때 `비회원`인 경우
특정 APIs 사용에 제한둘 수 있도록 하고자 JWT access token의 유효성
검증 middleware를 서버 APIs에 부분적으로 적용하였습니다.

## 👩‍💻 작업 사항

- `people_numbers` route 내 일부 APIs에 대하여 access token 유효성 검증 middleware 적용
- `places` route 내 일부 APIs에 대하여 access token 유효성 검증 middleware 적용

## ✅ 참고 사항

없습니다
