### PR TITLE
[fix]: DB 내 모든 Schema에 대하여 versionKey 생성 옵션 허용 (#30)

### DIFF
--- a/models/marker.js
+++ b/models/marker.js
@@ -1,14 +1,9 @@
 const mongoose = require('mongoose');
 
-const markerSchema = new mongoose.Schema(
-  {
-    latitude: String,
-    longitude: String,
-  },
-  {
-    versionKey: false,
-  }
-);
+const markerSchema = new mongoose.Schema({
+  latitude: String,
+  longitude: String,
+});
 
 const Marker = mongoose.model('markers', markerSchema);
 

--- a/models/people_number.js
+++ b/models/people_number.js
@@ -1,16 +1,11 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const peopleNumberSchema = new Schema(
-  {
-    placeId: { type: Schema.Types.ObjectId, ref: 'places' },
-    peopleCount: Number,
-    createdTime: String,
-  },
-  {
-    versionKey: false,
-  }
-);
+const peopleNumberSchema = new Schema({
+  placeId: { type: Schema.Types.ObjectId, ref: 'places' },
+  peopleCount: Number,
+  createdTime: String,
+});
 
 const PeopleNumber = mongoose.model('people_number', peopleNumberSchema);
 

--- a/models/place.js
+++ b/models/place.js
@@ -1,17 +1,12 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
-const placeSchema = new mongoose.Schema(
-  {
-    markerId: { type: Schema.Types.ObjectId, ref: 'markers' },
-    placeName: String,
-    address: String,
-    detailAddress: String,
-  },
-  {
-    versionKey: false,
-  }
-);
+const placeSchema = new mongoose.Schema({
+  markerId: { type: Schema.Types.ObjectId, ref: 'markers' },
+  placeName: String,
+  address: String,
+  detailAddress: String,
+});
 
 const Place = mongoose.model('places', placeSchema);
 


### PR DESCRIPTION
## 👀 이슈

resolve #30 

## 📌 개요

현재 DB 내에서 사용 중인 모든 `Schema`에 대하여 `versionKey` 생성 옵션이
비활성화 되어 있는데, 해당 옵션을 일괄적으로 허용하여 데이터의 일관성 문제가
나타나지 않도록 하였습니다.

## 👩‍💻 작업 사항

- `markers` Schema에 대한 `versionKey` 옵션 생성 허용
- `people_numbers` Schema에 대한 `versionKey` 옵션 생성 허용
- `places` Schema에 대한 `versionKey` 옵션 생성 허용

## ✅ 참고 사항

없습니다
