### PR TITLE
[feat]: 로그인/회원가입 APIs에 대한 swagger-doc 문서화 (#35)

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -14,9 +14,59 @@ const createHashedPassword = (password) => {
   return crypto.createHash('sha512').update(password).digest('base64');
 };
 
+/**
+ * @swagger
+ * /api/auth/public/login:
+ *   post:
+ *     tags:
+ *       - 회원 인증 API
+ *     summary: 로그인
+ *     description: 사용자 (이메일/비밀번호)를 통해 로그인 후 액세스 토큰을 발급합니다.
+ *     consumes:
+ *       - application/json
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - in: body
+ *         name: loginRequest
+ *         description: loginRequest
+ *         required: true
+ *         schema:
+ *           type: object
+ *           properties:
+ *             email:
+ *               type: string
+ *             password:
+ *               type: string
+ *     responses:
+ *       200:
+ *         description: OK
+ *         schema:
+ *           type: object
+ *           properties:
+ *             accessToken:
+ *               type: string
+ *               example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzaW5hYnJvIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo1MDUwIiwic3ViIjoiNjRiYWNhNDQxYjA2ZjU2OTJkNTljYTg1IiwiaWF0IjoxNjkwNDIxOTA3LCJleHAiOjE2OTA0MjI1MDd9.0SOH2JtMICYXxdglFzBeciuOD1MbZUqlEkm3zF_lPnU"
+ *       401:
+ *         description: Unauthorized
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Invalid credentials"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
 router.post('/public/login', async (req, res) => {
   if (!req.body.email || !req.body.password) {
-    return res.status(400).json({ message: 'bad request' });
+    return res.status(400).json({ error: 'bad request' });
   }
 
   try {
@@ -31,18 +81,85 @@ router.post('/public/login', async (req, res) => {
       });
 
       res.cookie('user', token);
-      return res.status(201).json(token);
+      return res.status(200).json({ accessToken: token });
     }
 
-    return res.status(400).json({ err: 'invalid user' });
+    return res.status(401).json({ error: 'Invalid credentials' });
   } catch (err) {
-    return res.status(400).json({ error: err.message });
+    return res.status(500).json({ error: err.error });
   }
 });
 
+/**
+ * @swagger
+ * /api/auth/public/signup:
+ *   post:
+ *     tags:
+ *       - 회원 인증 API
+ *     summary: 회원가입
+ *     description: (이메일, 비밀번호, 닉네임)을 통해 신규 회원을 등록합니다.
+ *     consumes:
+ *       - application/json
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - in: body
+ *         name: signUpRequest
+ *         description: signUpRequest
+ *         required: true
+ *         schema:
+ *           type: object
+ *           properties:
+ *             email:
+ *               type: string
+ *             password:
+ *               type: string
+ *             username:
+ *               type: string
+ *     responses:
+ *       201:
+ *         description: Created
+ *         schema:
+ *           type: object
+ *           properties:
+ *             email:
+ *               type: string
+ *               example: "abc@naver.com"
+ *             password:
+ *               type: string
+ *               example: "xwtd2ev7b1HQnUEytxcMnSB1CnhS8AaA9lZY8DEOgQBW5nY8NMmgCw6UAHb1RJXBafwjAszrMSA5JxxDRpUH3A=="
+ *             username:
+ *               type: string
+ *               example: "jenny"
+ *             role:
+ *               type: string
+ *               example: "member"
+ *             _id:
+ *               type: string
+ *               example: "64c1cc9d3a8b77048c1696aa"
+ *             __v:
+ *               type: number
+ *               example: 0
+ *       400:
+ *         description: Bad request
+ *         schema:
+ *           type: object
+ *           properties:
+ *             errror:
+ *               type: string
+ *               example: "Bad request or user with this email already exists"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
 router.post('/public/signup', async (req, res) => {
   if (!req.body.email || !req.body.password || !req.body.username) {
-    return res.status(400).json({ message: 'bad request' });
+    return res.status(400).json({ error: 'bad request' });
   }
 
   try {
@@ -51,9 +168,9 @@ router.post('/public/signup', async (req, res) => {
 
     // 이미 존재하는 이메일이면 에러 메시지를 전달
     if (existingUser) {
-      return res
-        .status(400)
-        .json({ message: 'A user with this email already exists.' });
+      return res.status(400).json({
+        error: 'Bad request or user with this email already exists',
+      });
     }
 
     const encryptedPassword = createHashedPassword(req.body.password);
@@ -68,7 +185,7 @@ router.post('/public/signup', async (req, res) => {
     const newUser = await new UserInfo(user).save();
     res.status(201).json(newUser);
   } catch (err) {
-    return res.status(500).json({ message: err.message });
+    return res.status(500).json({ error: err.error });
   }
 });
 

--- a/routes/middlewares/authorization.js
+++ b/routes/middlewares/authorization.js
@@ -1,18 +1,32 @@
 const jwt = require('jsonwebtoken');
 require('dotenv').config();
-
 const verifyToken = (req, res, next) => {
   try {
-    const clientToken = req.headers.cookie.replace('user=', '');
+    const userAgent = req.headers['user-agent'];
+    let clientToken = '';
+
+    switch (userAgent) {
+      // [VSCode Extension]: REST Client 전용
+      case 'vscode-restclient':
+        clientToken = req.headers.cookie.replace('user=', '');
+        break;
+      // [그 외]: Android Application, Swagger-UI 전용
+      default:
+        const clientTokenWithBearer = req.headers.authorization;
+        clientToken = clientTokenWithBearer.replace('Bearer ', ''); // Bearer 제거
+        clientToken = clientToken.replace(/['"]+/g, ''); // 쌍따옴표 제거
+        break;
+    }
+
     const decoded = jwt.verify(clientToken, process.env.JWT_TOKEN_SECRET);
     if (!decoded) {
-      return res.status(401).json({ error: 'Unauthorized' });
+      return res.status(401).json({ error: 'Token expried' });
     }
 
     res.locals.sub = decoded.id;
     next();
   } catch (err) {
-    return res.status(401).json({ error: 'Token expried' });
+    return res.status(401).json({ error: 'Unauthorized' });
   }
 };
 

--- a/server.js
+++ b/server.js
@@ -17,6 +17,15 @@ const swaggerOptions = {
       version: '1.0.0',
       description: 'Sinabro_API_DESCRIPTION',
     },
+    securityDefinitions: {
+      JWT: {
+        type: 'apiKey',
+        name: 'Authorization',
+        in: 'headers',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+    },
   },
   apis: ['./routes/*.js'], // files containing annotations as above
 };
@@ -48,9 +57,9 @@ app.use('/api/auth', userInfoRouter);
 const placeRouter = require('./routes/places');
 app.use('/api/places', placeRouter);
 
-// [people_numbers] collection에 대한 router 등록
-const peopleNumberRouter = require('./routes/people_numbers');
-app.use('/api/peopleNumbers', peopleNumberRouter);
+// [headcounts] collection에 대한 router 등록
+const headcountRouter = require('./routes/headcounts');
+app.use('/api/headcounts', headcountRouter);
 
 // [markers] collection에 대한 router 등록
 const markerRouter = require('./routes/markers');


### PR DESCRIPTION
## 👀 이슈

resolve #35 

## 📌 개요

#26 이슈 작업으로 인해 추가된 `로그인/회원가입` APIs에 대한
문서화를 수행하였습니다.

## 👩‍💻 작업 사항

- `로그인` API에 대한 `swagger-doc` 추가
- `회원가입` API에 대한 `swagger-doc` 추가
- `JWT(Json Web Token)` **verifying** middleware 내에 `clientToken`값 저장 로직 수정
- `JWT` 추가에 따른 `swaggerOptions` 내 JWT 이용에 대한 `securityDefinitions` 속성 추가
- #33 이슈 작업 중 누락된 작업 사항 커밋
> `people_numbers` collection name 변경으로 인한 router 엔드포인트 path 변경(`/api/peopleNumbers` -> `/api/headcounts`')

## ✅ 참고 사항

- JWT 사용을 위한 `Authorize` 기능 활성화

![Screenshot 2023-07-30 at 10 23 22 AM](https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/f3d7023b-5ddf-4983-bd1f-ec303eba7c61)