### PR TITLE
[feat]: 'auth' router 내에 '이메일 중복 확인' API 추가 (#39)

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -14,6 +14,29 @@ const createHashedPassword = (password) => {
   return crypto.createHash('sha512').update(password).digest('base64');
 };
 
+router.get('/public/search', async (req, res) => {
+  const email = req.query.email;
+  const regex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+  if (!regex.test(email)) {
+    return res.status(400).json({ error: 'Bad request' });
+  }
+
+  try {
+    // 이메일이 이미 존재하는지 확인
+    const existingUser = await UserInfo.findOne({ email });
+    // 이미 존재하는 이메일이면 에러 메시지를 전달
+    if (existingUser) {
+      return res.status(400).json({
+        error: 'User with this email already exists',
+      });
+    }
+
+    return res.status(200).json({ message: '아잉눈' });
+  } catch (err) {
+    return res.status(500).json({ error: err.error });
+  }
+});
+
 /**
  * @swagger
  * /api/auth/public/login:


### PR DESCRIPTION
## 👀 이슈

resolve #39 

## 📌 개요

애플리케이션 내에서 회원가입 1단계 중 사용자가 사용할 이메일을
입력하는 부분이 있는데, 해당 이메일은 현재 시스템에서 개별 회원의
고유한 아이디로써 사용되는 정보이기에 사용자는 사용하려는 이메일에 한하여
반드시 중복확인이 이뤄질 수 있도록 하고자 `이메일 중복 확인` API를 추가하고자
하였습니다.

## 👩‍💻 작업 사항

- `auth` router 내에 `이메일 중복 확인` API 추가

## ✅ 참고 사항

- `이메일 중복 확인` API에 대한 `swagger-doc` 추가는 추후에 진행하도록 하겠습니다
