### PR TITLE
[fix]: 이메일 중복 확인 API http status code 및 response body content 변경 (#41)

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -26,12 +26,12 @@ router.get('/public/search', async (req, res) => {
     const existingUser = await UserInfo.findOne({ email });
     // 이미 존재하는 이메일이면 에러 메시지를 전달
     if (existingUser) {
-      return res.status(400).json({
+      return res.status(409).json({
         error: 'User with this email already exists',
       });
     }
 
-    return res.status(200).json({ message: '아잉눈' });
+    return res.status(200).json({ error: 'OK' });
   } catch (err) {
     return res.status(500).json({ error: err.error });
   }


### PR DESCRIPTION
## 👀 이슈

resolve #41 

## 📌 개요

클라이언트 측에서 #39 이슈 작업을 통해 추가된 `이메일 중복 확인` API 사용 시
`이메일 형식 유효성 검증` 및 `이미 존재하는 이메일 확인`에 대한 `http status code`가
동일하여 상호 구분성이 다소 모호할 수 있다는 문제점이 있어 `이미 존재하는 이메일 확인`의
경우에 대한 http status code를 기존 400에서 409로 변경하였습니다.

## 👩‍💻 작업 사항

- `이메일 중복 확인` API 내 `이미 존재하는 이메일 확인`에 대한 http status code를 기존 `400`에서 `409`으로 변경
- `이메일 중복 확인` API 요청 성공 시 status code 200과 함께 반환되는 response body content 메시지 변경

## ✅ 참고 사항

없습니다
