### PR TITLE
[feat]: `회원 본인 정보 조회` API 추가 (#46)

### DIFF
--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -37,21 +37,19 @@ const router = express.Router();
 // :id값에 따른 document 중 placeId값이 :id와 동일한 document 설정 및 조회
 const getPlaceInformations = async (req, res, next) => {
   const placeId = req.params.id;
-  if (!mongoose.Types.ObjectId.isValid(placeId)) {
+  if (!mongoose.Types.ObjectId.isValid(placeId))
     return res.status(415).json({ error: 'Unsupported Media Type' });
-  }
 
   let placeInformations;
   try {
     placeInformations = await Headcount.find({ placeId });
-    if (!placeInformations) {
-      return res.status(404).json({ error: 'Not Found' });
-    }
+    if (!placeInformations) return res.status(404).json({ error: 'Not Found' });
+
+    res.placeInformations = placeInformations;
+    next();
   } catch (err) {
     return res.status(500).json({ error: err.error });
   }
-  res.placeInformations = placeInformations;
-  next();
 };
 
 // 인자로 들어온 배열의 각 요소인 Object에 updateElapsedTime 속성을 기준에 맞게 추가함
@@ -453,6 +451,14 @@ router.get(
  *             error:
  *               type: string
  *               example: "Bad Request"
+ *       401:
+ *         description: Unauthorized
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unauthorized"
  *       415:
  *         description: Unsupported Media Type
  *         schema:

--- a/routes/middlewares/authorization.js
+++ b/routes/middlewares/authorization.js
@@ -23,7 +23,7 @@ const verifyToken = (req, res, next) => {
       return res.status(401).json({ error: 'Token expried' });
     }
 
-    res.locals.sub = decoded.id;
+    res.locals.sub = decoded.sub;
     next();
   } catch (err) {
     return res.status(401).json({ error: 'Unauthorized' });

--- a/routes/places.js
+++ b/routes/places.js
@@ -42,22 +42,19 @@ const router = express.Router();
 // :id값에 따른 document 중 _id값이 :id와 동일한 document 설정 및 조회
 const getPlace = async (req, res, next) => {
   const placeId = req.params.id;
-  if (!mongoose.Types.ObjectId.isValid(placeId)) {
+  if (!mongoose.Types.ObjectId.isValid(placeId))
     return res.status(415).json({ error: 'Unsupported Media Type' });
-  }
 
   let place;
   try {
     place = await Place.findById(placeId);
-    if (!place) {
-      return res.status(404).json({ error: err.error });
-    }
+    if (!place) return res.status(404).json({ error: err.error });
+
+    res.place = place;
+    next();
   } catch (err) {
     return res.status(500).json({ error: err.error });
   }
-
-  res.place = place;
-  next();
 };
 
 /**

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,0 +1,90 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const UserInfo = require('../models/user_info');
+const { verifyToken } = require('./middlewares/authorization');
+const Place = require('../models/place');
+const router = express.Router();
+
+const getUserInfo = async (req, res, next) => {
+  let userId = req.params.id;
+  if (!userId) userId = res.locals.sub;
+
+  if (!mongoose.Types.ObjectId.isValid(userId))
+    return res.status(415).json({ error: 'Unsupported Media Type' });
+
+  let userInfo;
+  try {
+    userInfo = await UserInfo.findById(userId).select('-password -__v');
+    if (!userInfo) res.status(404).json({ error: 'Not Found' });
+
+    res.userInfo = userInfo;
+    next();
+  } catch (err) {
+    return res.status(500).json({ error: err.error });
+  }
+};
+
+/**
+ * @swagger
+ * /api/user/private/info:
+ *   get:
+ *    tags:
+ *      - 사용자 관련 API
+ *    summary: Get User Information
+ *    security:
+ *      - JWT: []
+ *    description: Retrieve the user information based on the user ID.
+ *    responses:
+ *      200:
+ *        description: OK
+ *        schema:
+ *          type: object
+ *          properties:
+ *            _id:
+ *              type: string
+ *            email:
+ *              type: string
+ *            username:
+ *              type: string
+ *            role:
+ *              type: string
+ *      401:
+ *        description: Unauthorized
+ *        schema:
+ *          type: object
+ *          properties:
+ *            error:
+ *              type: string
+ *              example: "Unauthorized"
+ *      404:
+ *        description: Not Found
+ *        schema:
+ *          type: object
+ *          properties:
+ *            error:
+ *              type: string
+ *              example: "Not Found"
+ *      415:
+ *        description: Unsupported Media Type
+ *        schema:
+ *          type: object
+ *          properties:
+ *            error:
+ *              type: string
+ *              example: "Unsupported Media Type"
+ *      500:
+ *        description: Internal Server Error
+ *        schema:
+ *          type: object
+ *          properties:
+ *            error:
+ *              type: string
+ *              example: "Internal Server Error"
+ */
+router.get('/private/info', verifyToken, getUserInfo, async (req, res) => {
+  const userInfo = res.userInfo;
+  console.log(userInfo);
+  return res.status(200).json(userInfo);
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -49,9 +49,13 @@ app.use(express.static(path.join(__dirname, 'public')));
 const swaggerDocs = swaggerJsDoc(swaggerOptions);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 
+// [user_infos] collection에 인증 대한 router 등록
+const userInfoAuthRouter = require('./routes/auth');
+app.use('/api/auth', userInfoAuthRouter);
+
 // [user_infos] collection에 대한 router 등록
-const userInfoRouter = require('./routes/auth');
-app.use('/api/auth', userInfoRouter);
+const userInfoRouter = require('./routes/users');
+app.use('/api/user', userInfoRouter);
 
 // [places] collection에 대한 router 등록
 const placeRouter = require('./routes/places');


### PR DESCRIPTION
## 👀 이슈

resolve #46 

## 📌 개요

클라이언트 측에서 회원 본인의 정보를 조회해야 하는 경우에 대하여
해당 기능을 수행할 수 있도록 클라이언트 측에서 유효한 access token을
담아 API를 요청하였을 경우 DB 내 `user_infos` collection에서 회원 정보와
관련된 데이터를 응답으로 보내는 API를 추가하였습니다.

## 👩‍💻 작업 사항

- `user` router 추가
> 회원 본인 정보 조회 API 추가 (GET, **`/api/private/user/info`**)
- 회원 인증 관련 APIs router명 변경
- `headcounts`, `places` collection에 대한 router 내 코드 일부 수정
- authorization middleware 코드 내 JWT 복호화 object명 정정

## ✅ 참고 사항

없습니다