### PR TITLE
[fix]: 신규 장소 등록 API Bad Request(400) 검증 로직 수정 (#50)

### DIFF
--- a/routes/places.js
+++ b/routes/places.js
@@ -125,9 +125,9 @@ router.get('/', async (req, res) => {
  *             detailAddress:
  *               type: string
  *             latitude:
- *               type: number
+ *               type: string
  *             longitude:
- *               type: number
+ *               type: string
  *     responses:
  *       201:
  *         description: Created
@@ -176,8 +176,8 @@ router.post('/private', verifyToken, async (req, res) => {
     !req.body.placeName ||
     !req.body.address ||
     !req.body.detailAddress ||
-    typeof req.body.latitude !== 'number' ||
-    typeof req.body.longitude !== 'number'
+    !req.body.latitude ||
+    !req.body.longitude
   ) {
     return res.status(400).json({ error: 'Bad Request' });
   }

--- a/routes/users.js
+++ b/routes/users.js
@@ -83,7 +83,6 @@ const getUserInfo = async (req, res, next) => {
  */
 router.get('/private/info', verifyToken, getUserInfo, async (req, res) => {
   const userInfo = res.userInfo;
-  console.log(userInfo);
   return res.status(200).json(userInfo);
 });
 


### PR DESCRIPTION
## 👀 이슈

resolve #50 

## 📌 개요

`신규 장소 등록` API를 사용하려면 request body에 문자열형으로
latitude(위도), longitude(경도) 값을 넘겨줘야 하는데, 실제 API
구성 코드 내에 `Bad Request(400)`를 판단하는 조건문에서 request body에
담긴 위도, 경도 값이 숫자형(number)이 아닐 때 참이라는 조건으로 구성되어 있어
`문자열형`으로 넘어온 해당 두 값들에 의하여 `Bad Request(400)` 에러가 발생하여
해당 문제를 수정하였습니다.

## 👩‍💻 작업 사항

- `신규 장소 등록` API 내에 `Bad Request(400)` 판단 조건문 중
latitude, longitude 판단 조건식 수정
- `users` router 내에 불필요 `console.log` 함수 사용 코드 라인 제거

## ✅ 참고 사항

없습니다
