### PR TITLE
[feat]: 비밀번호 변경 API 추가 (#52)

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -75,7 +75,7 @@ router.get('/public/search', async (req, res) => {
 
     return res.status(200).json({ message: 'OK' });
   } catch (err) {
-    return res.status(500).json({ error: err.error });
+    return res.status(500).json({ error: err.message });
   }
 });
 
@@ -130,14 +130,15 @@ router.get('/public/search', async (req, res) => {
  *               example: "Internal Server Error"
  */
 router.post('/public/login', async (req, res) => {
-  if (!req.body.email || !req.body.password) {
+  const { email, password } = req.body;
+
+  if (!email || !password)
     return res.status(400).json({ error: 'Bad request' });
-  }
 
   try {
     const user = await UserInfo.findOne({
-      email: req.body.email,
-      password: createHashedPassword(req.body.password),
+      email,
+      password: createHashedPassword(password),
     });
     if (user) {
       options.sub = user._id;
@@ -151,7 +152,7 @@ router.post('/public/login', async (req, res) => {
 
     return res.status(401).json({ error: 'Invalid credentials' });
   } catch (err) {
-    return res.status(500).json({ error: err.error });
+    return res.status(500).json({ error: err.message });
   }
 });
 
@@ -223,13 +224,15 @@ router.post('/public/login', async (req, res) => {
  *               example: "Internal Server Error"
  */
 router.post('/public/signup', async (req, res) => {
-  if (!req.body.email || !req.body.password || !req.body.username) {
+  const { email, password, username } = req.body;
+
+  if (!email || !password || !username) {
     return res.status(400).json({ error: 'Bad request' });
   }
 
   try {
     // 이메일이 이미 존재하는지 확인
-    const existingUser = await UserInfo.findOne({ email: req.body.email });
+    const existingUser = await UserInfo.findOne({ email });
 
     // 이미 존재하는 이메일이면 에러 메시지를 전달
     if (existingUser) {
@@ -238,19 +241,17 @@ router.post('/public/signup', async (req, res) => {
       });
     }
 
-    const encryptedPassword = createHashedPassword(req.body.password);
-
     const user = new UserInfo({
-      email: req.body.email,
-      password: encryptedPassword,
-      username: req.body.username,
+      email,
+      password: createHashedPassword(password),
+      username,
       role: 'member',
     });
 
     const newUser = await new UserInfo(user).save();
     res.status(201).json(newUser);
   } catch (err) {
-    return res.status(500).json({ error: err.error });
+    return res.status(500).json({ error: err.message });
   }
 });
 

--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -48,7 +48,7 @@ const getPlaceInformations = async (req, res, next) => {
     res.placeInformations = placeInformations;
     next();
   } catch (err) {
-    return res.status(500).json({ error: err.error });
+    return res.status(500).json({ error: err.message });
   }
 };
 
@@ -133,7 +133,7 @@ router.get('/', async (req, res) => {
 
     res.status(200).json(placeInformations);
   } catch (err) {
-    res.status(500).json({ error: err.error });
+    res.status(500).json({ error: err.message });
   }
 });
 
@@ -221,7 +221,7 @@ router.get('/public/placeInformations', async (req, res) => {
 
     res.status(200).json(updatedPlaceInformations);
   } catch (err) {
-    res.status(500).json({ error: err.error });
+    res.status(500).json({ error: err.message });
   }
 });
 
@@ -395,7 +395,7 @@ router.get(
       );
       res.status(200).json(updatedPlaceInformations);
     } catch (err) {
-      res.status(500).json({ error: err.error });
+      res.status(500).json({ error: err.message });
     }
   }
 );
@@ -493,7 +493,7 @@ router.post(
       const newHeadcount = await headcount.save();
       res.status(201).json(newHeadcount);
     } catch (err) {
-      res.status(500).json({ error: err.error });
+      res.status(500).json({ error: err.message });
     }
   }
 );

--- a/routes/markers.js
+++ b/routes/markers.js
@@ -66,7 +66,7 @@ router.get('/', async (req, res) => {
 
     res.status(200).json(markers);
   } catch (err) {
-    res.status(500).json({ error: err.error });
+    res.status(500).json({ error: err.message });
   }
 });
 

--- a/routes/places.js
+++ b/routes/places.js
@@ -48,12 +48,12 @@ const getPlace = async (req, res, next) => {
   let place;
   try {
     place = await Place.findById(placeId);
-    if (!place) return res.status(404).json({ error: err.error });
+    if (!place) return res.status(404).json({ error: err.message });
 
     res.place = place;
     next();
   } catch (err) {
-    return res.status(500).json({ error: err.error });
+    return res.status(500).json({ error: err.message });
   }
 };
 
@@ -97,7 +97,7 @@ router.get('/', async (req, res) => {
     }
     res.status(200).json(places);
   } catch (err) {
-    res.status(500).json({ error: err.error });
+    res.status(500).json({ error: err.message });
   }
 });
 
@@ -172,23 +172,18 @@ router.get('/', async (req, res) => {
  *               example: "Internal Server Error"
  */
 router.post('/private', verifyToken, async (req, res) => {
-  if (
-    !req.body.placeName ||
-    !req.body.address ||
-    !req.body.detailAddress ||
-    !req.body.latitude ||
-    !req.body.longitude
-  ) {
+  const { placeName, address, detailAddress, latitude, longitude } = req.body;
+
+  if (!placeName || !address || !detailAddress || !latitude || !longitude)
     return res.status(400).json({ error: 'Bad Request' });
-  }
 
   let markerId;
   let newMarker;
 
   try {
     marker = await Marker.findOne({
-      latitude: req.body.latitude,
-      longitude: req.body.longitude,
+      latitude,
+      longitude,
     });
     if (!marker) {
       newMarker = new Marker(req.body);
@@ -202,7 +197,7 @@ router.post('/private', verifyToken, async (req, res) => {
       markerId = marker.id;
     }
   } catch (err) {
-    res.status(500).json({ error: err.error });
+    res.status(500).json({ error: err.message });
   }
 
   try {
@@ -220,14 +215,14 @@ router.post('/private', verifyToken, async (req, res) => {
     const newHeadcount = await headcount.save();
     res.status(201).json(newPlace);
   } catch (err) {
-    res.status(500).json({ error: err.error });
+    res.status(500).json({ error: err.message });
   }
 });
 
 /**
  * @swagger
  * /api/places/private/{placeId}:
- *   patch:
+ *   put:
  *     tags:
  *       - Places Collection 기반 API
  *     summary: 장소 정보 업데이트
@@ -284,15 +279,17 @@ router.post('/private', verifyToken, async (req, res) => {
  *               type: string
  *               example: "Internal Server Error"
  */
-router.patch('/private/:id', verifyToken, getPlace, async (req, res) => {
-  if (req.body.placeName != null) res.place.placeName = req.body.placeName;
-  if (req.body.detailAddress != null)
-    res.place.detailAddress = req.body.detailAddress;
+router.put('/private/:id', verifyToken, getPlace, async (req, res) => {
+  const { placeName, detailAdress } = req.body;
+
+  if (!placeName) res.place.placeName = placeName;
+  if (!detailAddress) res.place.detailAddress = detailAddress;
+
   try {
     const updatedPlace = await res.place.save();
     res.status(200).json(updatedPlace);
   } catch (err) {
-    res.status(500).json({ error: err.error });
+    res.status(500).json({ error: err.message });
   }
 });
 
@@ -358,11 +355,11 @@ router.delete('/private/:id', verifyToken, getPlace, async (req, res) => {
         // markers collection 내 삭제하려는 장소의 _id값을 지닌 연관 document 제거
         await Marker.deleteOne({ _id: res.place.markerId });
       } catch (err) {
-        res.status(500).json({ error: err.error });
+        res.status(500).json({ error: err.message });
       }
     }
   } catch (err) {
-    res.status(500).json({ error: err.error });
+    res.status(500).json({ error: err.message });
   }
 
   try {
@@ -371,7 +368,7 @@ router.delete('/private/:id', verifyToken, getPlace, async (req, res) => {
     await res.place.deleteOne();
     res.status(200).json({ remainingPlacesCnt: places.length - 1 });
   } catch (err) {
-    res.status(500).json({ error: err.error });
+    res.status(500).json({ error: err.message });
   }
 });
 


### PR DESCRIPTION
## 👀 이슈

resolve #52 

## 📌 개요

클라이언트 측 애플리케이션 내에서 사용자가 `마이페이지` 액티비티 내에서
원하는 경우 본인의 계정 비밀번호를 새롭게 변경할 수 있도록 하는 `비밀번호 변경`
API를 추가하였습니다.

## 👩‍💻 작업 사항

- `비밀번호 변경` API 및 `swagger-doc` 추가
- http status code 500에 대한 error 메시지 속성 정정
- 일부 APIs `http request body`에 대한 object destructuring 적용
- `장소 정보 업데이트` API에 대한 `http method` 변경
> (기존) `PATCH` → (변경 후) `PUT`)

## ✅ 참고 사항

- `비밀번호 변경` API에 대한 swagger-doc 화면

<img width="972" alt="Screenshot 2023-08-06 at 5 33 39 PM" src="https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/d42f530b-c7c8-445f-8205-571ad93b876f">