### PR TITLE
[fix]: '장소 정보 수정' API 오류 수정 (#56)

### DIFF
--- a/routes/places.js
+++ b/routes/places.js
@@ -225,10 +225,10 @@ router.post('/private', verifyToken, async (req, res) => {
  *   put:
  *     tags:
  *       - Places Collection 기반 API
- *     summary: 장소 정보 업데이트
+ *     summary: 장소 정보 수정
  *     security:
  *       - JWT: []
- *     description: 특정 장소를 새로운 정보로 업데이트 합니다.
+ *     description: 특정 장소를 새로운 정보로 수정합니다.
  *     parameters:
  *       - in: path
  *         name: placeId
@@ -254,6 +254,14 @@ router.post('/private', verifyToken, async (req, res) => {
  *         description: OK
  *         schema:
  *           $ref: '#/definitions/Place'
+ *       400:
+ *         description: Bad request
+ *         schema:
+ *           type: object
+ *           properties:
+ *             errror:
+ *               type: string
+ *               example: "Bad Request"
  *       401:
  *         description: Unauthorized
  *         schema:
@@ -280,10 +288,12 @@ router.post('/private', verifyToken, async (req, res) => {
  *               example: "Internal Server Error"
  */
 router.put('/private/:id', verifyToken, getPlace, async (req, res) => {
-  const { placeName, detailAdress } = req.body;
+  const { placeName, detailAddress } = req.body;
+  if (!placeName || !detailAddress)
+    return res.status(400).json({ error: 'Bad Request' });
 
-  if (!placeName) res.place.placeName = placeName;
-  if (!detailAddress) res.place.detailAddress = detailAddress;
+  res.place.placeName = placeName;
+  res.place.detailAddress = detailAddress;
 
   try {
     const updatedPlace = await res.place.save();


### PR DESCRIPTION
## 👀 이슈

resolve #56 

## 📌 개요

기존 `장소 정보 수정` API의 경우 `Bad Request`에 대한 검증 단계가 존재하지 않았고,
`res.place` 값을 설정하는 부분의 로직이 의도하지 않은 방향으로 작동되는 버그가 있었기
때문에 해당 문제들을 해결하였습니다.

## 👩‍💻 작업 사항

- `places` router` 내 `장소 정보 수정` API 로직 수정

## ✅ 참고 사항

없습니다
