### PR TITLE
[feat]: 즐겨찾기 리스트 관련 APIs 추가 (#45)

### DIFF
--- a/models/bookmark.js
+++ b/models/bookmark.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const bookmarkSchema = new Schema({
+  userId: { type: Schema.Types.ObjectId, ref: 'user_infos' },
+  bookmarkName: String,
+  iconColor: String,
+});
+
+const Bookmark = mongoose.model('bookmarks', bookmarkSchema);
+module.exports = Bookmark;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -86,11 +86,9 @@ router.get('/public/search', async (req, res) => {
  *     tags:
  *       - 회원 인증 API
  *     summary: 로그인
+ *     security:
+ *      - JWT: []
  *     description: 사용자 (이메일/비밀번호)를 통해 로그인 후 액세스 토큰을 발급합니다.
- *     consumes:
- *       - application/json
- *     produces:
- *       - application/json
  *     parameters:
  *       - in: body
  *         name: loginRequest
@@ -249,7 +247,7 @@ router.post('/public/signup', async (req, res) => {
     });
 
     const newUser = await new UserInfo(user).save();
-    res.status(201).json(newUser);
+    return res.status(201).json(newUser);
   } catch (err) {
     return res.status(500).json({ error: err.message });
   }

--- a/routes/bookmarks.js
+++ b/routes/bookmarks.js
@@ -1,0 +1,434 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const Bookmark = require('../models/bookmark');
+const UserInfo = require('../models/user_info');
+const { verifyToken } = require('./middlewares/authorization');
+const router = express.Router();
+
+/** ⚙️ [bookmarks] collection에 대한 Model definition
+ * @swagger
+ * definitions:
+ *   Bookmark:
+ *     type: object
+ *     required:
+ *       - _id
+ *       - userId
+ *       - bookmarkName
+ *       - iconColor
+ *     properties:
+ *       _id:
+ *         type: string
+ *         description: bookmarkId
+ *       userId:
+ *         type: string
+ *         description: bookmarkId와 연관된 userId
+ *       bookmarkName:
+ *         type: string
+ *         description: 북마크 리스트 이름
+ *       iconColor:
+ *         type: string
+ *         description: 북마크 리스트 아이콘 색상
+ *       __v:
+ *         type: number
+ *         description: version key
+ */
+
+// :id값에 따른 document 중 bookmarkId값이 :id와 동일한 document 설정 및 조회
+const getBookmark = async (req, res, next) => {
+  const bookmarkId = req.params.id;
+  if (!mongoose.Types.ObjectId.isValid(bookmarkId))
+    return res.status(415).json({ error: 'Unsupported Media Type' });
+
+  try {
+    const bookmark = await Bookmark.findById(bookmarkId);
+    if (!bookmark) return res.status(404).json({ error: 'Not Found' });
+
+    res.bookmark = bookmark;
+    next();
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
+
+// :id값에 따른 document 중 userId값이 :id와 동일한 document 설정 및 조회
+const getUserInfo = async (req, res, next) => {
+  let userId = req.params.id;
+  if (!userId) userId = res.locals.sub;
+
+  if (!mongoose.Types.ObjectId.isValid(userId))
+    return res.status(415).json({ error: 'Unsupported Media Type' });
+
+  try {
+    const userInfo = await UserInfo.findById(userId).select('-password -__v');
+    if (!userInfo) return res.status(404).json({ error: 'Not Found' });
+
+    res.userInfo = userInfo;
+    next();
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/bookmarks:
+ *   get:
+ *     tags:
+ *       - Bookmarks Collection 기반 API
+ *     summary: (bookmarks) Collection 내의 모든 Document(s) 반환 ➜ [In-App use ❌]
+ *     description: (bookmarks) collection 내의 모든 데이터 목록을 반환합니다.
+ *     responses:
+ *       200:
+ *         description: OK
+ *         schema:
+ *           items:
+ *             $ref: '#/definitions/Bookmark'
+ *       404:
+ *         description: Not Found
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Not Found"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
+router.get('/', async (req, res) => {
+  try {
+    const bookmarks = await Bookmark.find();
+    if (!bookmarks) return res.status(400).json({ error: 'Not Found' });
+
+    return res.status(200).json(bookmarks);
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * @swagger
+ * /api/bookmarks/private:
+ *   get:
+ *     tags:
+ *       - Bookmarks Collection 기반 API
+ *     summary: 특정 회원의 즐겨찾기 리스트 정보 목록 반환
+ *     security:
+ *       - JWT: []
+ *     description: (bookmarks) collection 내에서 사용자가 등록한 즐겨찾기 리스트 정보 목록을 반환합니다.
+ *     responses:
+ *       200:
+ *         description: OK
+ *         schema:
+ *           items:
+ *             $ref: '#/definitions/Bookmark'
+ *       401:
+ *         description: Unauthorized
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unauthorized"
+ *       404:
+ *         description: Not Found
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Not Found"
+ *       415:
+ *         description: Unsupported Media Type
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unsupported Media Type"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
+router.get('/private', verifyToken, getUserInfo, async (req, res) => {
+  const userInfo = res.userInfo;
+
+  try {
+    const bookmarks = await Bookmark.find({ userId: userInfo._id });
+    if (!bookmarks) return res.status(400).json({ error: 'Not Found' });
+
+    return res.status(200).json(bookmarks);
+  } catch (err) {
+    return res.status(500).json({ message: err.message });
+  }
+});
+
+/**
+ * @swagger
+ * /api/bookmarks/private:
+ *   post:
+ *     tags:
+ *       - Bookmarks Collection 기반 API
+ *     summary: 신규 북마크 리스트 등록
+ *     security:
+ *       - JWT: []
+ *     description: 새로운 북마크 리스트를 추가합니다.
+ *     parameters:
+ *       - in: body
+ *         name: bookmarksRequest
+ *         required: true
+ *         schema:
+ *           type: object
+ *           properties:
+ *             bookmarkName:
+ *               type: string
+ *             iconColor:
+ *               type: string
+ *     responses:
+ *       201:
+ *         description: Created
+ *         schema:
+ *           properties:
+ *             _id:
+ *               type: string
+ *             userId:
+ *               type: string
+ *             bookmarkName:
+ *               type: string
+ *             iconColor:
+ *               type: string
+ *             __v:
+ *               type: number
+ *       400:
+ *         description: Bad Request
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Bad Request"
+ *       401:
+ *         description: Unauthorized
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unauthorized"
+ *       404:
+ *         description: Not Found
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Not Found"
+ *       415:
+ *         description: Unsupported Media Type
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unsupported Media Type"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
+router.post('/private', verifyToken, getUserInfo, async (req, res) => {
+  const { bookmarkName, iconColor } = req.body;
+
+  if (!bookmarkName || !iconColor)
+    return res.status(400).json({ error: 'Bad Request' });
+
+  const userInfo = res.userInfo;
+
+  try {
+    const bookmark = new Bookmark(req.body);
+    bookmark.userId = userInfo._id;
+    const newBookmark = await bookmark.save();
+    return res.status(201).json(newBookmark);
+  } catch (err) {
+    return res.status(500).json({ err: err.message });
+  }
+});
+
+/**
+ * @swagger
+ * /api/bookmarks/private/{bookmarkId}:
+ *   patch:
+ *    tags:
+ *      - Bookmarks Collection 기반 API
+ *    summary: 북마크 리스트 정보 수정
+ *    security:
+ *      - JWT: []
+ *    description: 북마크 리스트 정보를 수정합니다.
+ *    parameters:
+ *      - in: path
+ *        name: bookmarkId
+ *        required: true
+ *        description: bookmarkId
+ *        type: string
+ *      - in: body
+ *        name: passwordRequest
+ *        required: true
+ *        schema:
+ *          type: object
+ *          properties:
+ *            bookmarkName:
+ *              type: string
+ *            iconColor:
+ *              type: string
+ *    responses:
+ *      200:
+ *        description: OK
+ *        schema:
+ *          type: object
+ *          properties:
+ *            message:
+ *              type: string
+ *              example: "OK"
+ *      400:
+ *        description: Bad request
+ *        schema:
+ *          type: object
+ *          properties:
+ *            errror:
+ *              type: string
+ *              example: "Bad Request"
+ *      401:
+ *        description: Unauthorized
+ *        schema:
+ *          type: object
+ *          properties:
+ *            error:
+ *              type: string
+ *              example: "Unauthorized"
+ *      404:
+ *        description: Not Found
+ *        schema:
+ *          type: object
+ *          properties:
+ *            error:
+ *              type: string
+ *              example: "Not Found"
+ *      415:
+ *        description: Unsupported Media Type
+ *        schema:
+ *          type: object
+ *          properties:
+ *            error:
+ *              type: string
+ *              example: "Unsupported Media Type"
+ *      500:
+ *        description: Internal Server Error
+ *        schema:
+ *          type: object
+ *          properties:
+ *            error:
+ *              type: string
+ *              example: "Internal Server Error"
+ */
+router.patch('/private/:id', verifyToken, getBookmark, async (req, res) => {
+  const { bookmarkName, iconColor } = req.body;
+
+  if (!bookmarkName || !iconColor)
+    return res.status(400).json({ error: 'Bad Request' });
+
+  const bookmark = res.bookmark;
+
+  try {
+    const result = await Bookmark.updateMany(
+      { _id: bookmark._id }, // Filter
+      { $set: { bookmarkName, iconColor } } // Update action
+    );
+
+    return res.status(200).json({ message: 'OK' });
+  } catch (err) {
+    return res.status(200).json({ err: err.message });
+  }
+});
+
+/**
+ * @swagger
+ * /api/bookmarks/private/{bookmarkId}:
+ *   delete:
+ *     tags:
+ *       - Bookmarks Collection 기반 API
+ *     summary: 특정 북마크 리스트 제거
+ *     security:
+ *       - JWT: []
+ *     description: 특정 북마크 리스트 정보를 담고 있는 document를 제거합니다.
+ *     parameters:
+ *       - in: path
+ *         name: bookmarkId
+ *         required: true
+ *         description: bookmarkId
+ *         type: string
+ *     responses:
+ *       200:
+ *         description: OK
+ *         schema:
+ *           type: object
+ *           properties:
+ *             message:
+ *               type: string
+ *               example: "OK"
+ *       401:
+ *         description: Unauthorized
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: number
+ *               example: "Unauthorized"
+ *       404:
+ *         description: Not Found
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Not Found"
+ *       415:
+ *         description: Unsupported Media Type
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unsupported Media Type"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
+router.delete('/private/:id', verifyToken, getBookmark, async (req, res) => {
+  try {
+    await res.bookmark.deleteOne();
+    return res.status(200).json({ message: 'OK' });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -34,15 +34,14 @@ const router = express.Router();
  *         description: version key
  */
 
-// :id값에 따른 document 중 placeId값이 :id와 동일한 document 설정 및 조회
+// :id값에 따른 document 중 placeId값이 :id와 동일한 document(s) 설정 및 조회
 const getPlaceInformations = async (req, res, next) => {
   const placeId = req.params.id;
   if (!mongoose.Types.ObjectId.isValid(placeId))
     return res.status(415).json({ error: 'Unsupported Media Type' });
 
-  let placeInformations;
   try {
-    placeInformations = await Headcount.find({ placeId });
+    const placeInformations = await Headcount.find({ placeId });
     if (!placeInformations) return res.status(404).json({ error: 'Not Found' });
 
     res.placeInformations = placeInformations;
@@ -98,7 +97,7 @@ const addUpdateElapsedTimeProp = (currPlaceInformations) => {
  * /api/headcounts:
  *   get:
  *     tags:
- *       - Headcount Collection 기반 API
+ *       - Headcounts Collection 기반 API
  *     summary: (headcounts) Collection 내의 모든 Document(s) 반환 ➜ [In-App use ❌]
  *     description: (headcounts) collection 내의 모든 데이터 목록을 반환합니다.
  *     responses:
@@ -127,13 +126,11 @@ const addUpdateElapsedTimeProp = (currPlaceInformations) => {
 router.get('/', async (req, res) => {
   try {
     const placeInformations = await Headcount.find();
-    if (!placeInformations) {
-      return res.status(404).json({ error: 'Not Found' });
-    }
+    if (!placeInformations) return res.status(404).json({ error: 'Not Found' });
 
-    res.status(200).json(placeInformations);
+    return res.status(200).json(placeInformations);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 });
 
@@ -142,7 +139,7 @@ router.get('/', async (req, res) => {
  * /api/headcounts/public/placeInformations:
  *   get:
  *     tags:
- *       - Headcount Collection 기반 API
+ *       - Headcounts Collection 기반 API
  *     summary: 등록된 모든 장소에 대한 세부 정보 반환
  *     description: 각 장소에 대한 인원수와 장소 세부 정보 목록을 반환합니다.
  *     responses:
@@ -219,9 +216,9 @@ router.get('/public/placeInformations', async (req, res) => {
     const updatedPlaceInformations =
       addUpdateElapsedTimeProp(placeInformations);
 
-    res.status(200).json(updatedPlaceInformations);
+    return res.status(200).json(updatedPlaceInformations);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 });
 
@@ -230,7 +227,7 @@ router.get('/public/placeInformations', async (req, res) => {
  * /api/headcounts/{placeId}:
  *   get:
  *     tags:
- *       - Headcount Collection 기반 API
+ *       - Headcounts Collection 기반 API
  *     summary: 특정 장소에 대한 인원수 세부 정보 반환 ➜ [In-App use ❌]
  *     description: 특정 장소에 대한 인원수 세부 정보를 반환합니다.
  *     parameters:
@@ -287,7 +284,7 @@ router.get('/:id', getPlaceInformations, async (req, res) => {
   const updatedPlaceInformations = addUpdateElapsedTimeProp(
     res.placeInformations
   );
-  res.status(200).json(updatedPlaceInformations[0]);
+  return res.status(200).json(updatedPlaceInformations[0]);
 });
 
 /**
@@ -295,7 +292,7 @@ router.get('/:id', getPlaceInformations, async (req, res) => {
  * /api/headcounts/public/{markerId}/placeInformations:
  *   get:
  *     tags:
- *       - Headcount Collection 기반 API
+ *       - Headcounts Collection 기반 API
  *     summary: 특정 마커 위치에 대한 장소 정보 및 인원수 세부 정보 반환
  *     description: 특정 마커 위치에 대한 장소 정보 및 인원수 세부 정보를 반환합니다.
  *     parameters:
@@ -393,9 +390,9 @@ router.get(
       const updatedPlaceInformations = addUpdateElapsedTimeProp(
         filteredPlaceInformations
       );
-      res.status(200).json(updatedPlaceInformations);
+      return res.status(200).json(updatedPlaceInformations);
     } catch (err) {
-      res.status(500).json({ error: err.message });
+      return res.status(500).json({ error: err.message });
     }
   }
 );
@@ -405,7 +402,7 @@ router.get(
  * /api/headcounts/private/{placeId}:
  *   post:
  *     tags:
- *       - Headcount Collection 기반 API
+ *       - Headcounts Collection 기반 API
  *     summary: 특정 장소에 대한 인원수 등록
  *     security:
  *       - JWT: []
@@ -481,9 +478,8 @@ router.post(
   verifyToken,
   getPlaceInformations,
   async (req, res) => {
-    if (typeof req.body.headcount !== 'number') {
+    if (typeof req.body.headcount !== 'number')
       return res.status(400).json({ error: 'Bad Request' });
-    }
 
     const headcount = new Headcount(req.body);
     headcount.placeId = req.params.id;
@@ -491,9 +487,9 @@ router.post(
 
     try {
       const newHeadcount = await headcount.save();
-      res.status(201).json(newHeadcount);
+      return res.status(201).json(newHeadcount);
     } catch (err) {
-      res.status(500).json({ error: err.message });
+      return res.status(500).json({ error: err.message });
     }
   }
 );

--- a/routes/markers.js
+++ b/routes/markers.js
@@ -64,9 +64,9 @@ router.get('/', async (req, res) => {
       return res.status(404).json({ error: 'Not Found' });
     }
 
-    res.status(200).json(markers);
+    return res.status(200).json(markers);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 });
 

--- a/routes/places.js
+++ b/routes/places.js
@@ -45,9 +45,8 @@ const getPlace = async (req, res, next) => {
   if (!mongoose.Types.ObjectId.isValid(placeId))
     return res.status(415).json({ error: 'Unsupported Media Type' });
 
-  let place;
   try {
-    place = await Place.findById(placeId);
+    const place = await Place.findById(placeId);
     if (!place) return res.status(404).json({ error: err.message });
 
     res.place = place;
@@ -91,13 +90,11 @@ const getPlace = async (req, res, next) => {
 router.get('/', async (req, res) => {
   try {
     const places = await Place.find();
-    if (!places) {
-      res.status(404).json({ error: 'Not Found' });
-      return;
-    }
-    res.status(200).json(places);
+    if (!places) return res.status(404).json({ error: 'Not Found' });
+
+    return res.status(200).json(places);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 });
 
@@ -191,13 +188,13 @@ router.post('/private', verifyToken, async (req, res) => {
       try {
         await newMarker.save();
       } catch (err) {
-        res.status(400).json({ error: 'Bad Request' });
+        return res.status(400).json({ error: 'Bad Request' });
       }
     } else {
       markerId = marker.id;
     }
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 
   try {
@@ -213,9 +210,9 @@ router.post('/private', verifyToken, async (req, res) => {
     });
 
     const newHeadcount = await headcount.save();
-    res.status(201).json(newPlace);
+    return res.status(201).json(newPlace);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 });
 
@@ -297,9 +294,9 @@ router.put('/private/:id', verifyToken, getPlace, async (req, res) => {
 
   try {
     const updatedPlace = await res.place.save();
-    res.status(200).json(updatedPlace);
+    return res.status(200).json(updatedPlace);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 });
 
@@ -365,20 +362,20 @@ router.delete('/private/:id', verifyToken, getPlace, async (req, res) => {
         // markers collection 내 삭제하려는 장소의 _id값을 지닌 연관 document 제거
         await Marker.deleteOne({ _id: res.place.markerId });
       } catch (err) {
-        res.status(500).json({ error: err.message });
+        return res.status(500).json({ error: err.message });
       }
     }
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 
   try {
     // (headcounts) collection 내 삭제하려는 장소의 _id값을 지닌 연관 document(들) 일괄 제거
     await Headcount.deleteMany({ placeId: res.place._id });
     await res.place.deleteOne();
-    res.status(200).json({ remainingPlacesCnt: places.length - 1 });
+    return res.status(200).json({ remainingPlacesCnt: places.length - 1 });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: err.message });
   }
 });
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -16,9 +16,8 @@ const getUserInfo = async (req, res, next) => {
   if (!mongoose.Types.ObjectId.isValid(userId))
     return res.status(415).json({ error: 'Unsupported Media Type' });
 
-  let userInfo;
   try {
-    userInfo = await UserInfo.findById(userId).select('-password -__v');
+    const userInfo = await UserInfo.findById(userId).select('-password -__v');
     if (!userInfo) return res.status(404).json({ error: 'Not Found' });
 
     res.userInfo = userInfo;
@@ -117,7 +116,7 @@ router.get('/private/info', verifyToken, getUserInfo, async (req, res) => {
  *        schema:
  *          type: object
  *          properties:
- *            error:
+ *            message:
  *              type: string
  *              example: "OK"
  *      400:
@@ -228,7 +227,7 @@ router.patch('/private/info', verifyToken, getUserInfo, async (req, res) => {
  *        schema:
  *          type: object
  *          properties:
- *            error:
+ *            message:
  *              type: string
  *              example: "OK"
  *      400:

--- a/server.js
+++ b/server.js
@@ -69,6 +69,10 @@ app.use('/api/headcounts', headcountRouter);
 const markerRouter = require('./routes/markers');
 app.use('/api/markers', markerRouter);
 
+// [bookmarks] collection에 대한 router 등록
+const bookmarkRouter = require('./routes/bookmarks');
+app.use('/api/bookmarks', bookmarkRouter);
+
 app.listen(port, () => {
   console.log('Server started on port 5050');
 });


### PR DESCRIPTION
## 👀 이슈

resolve #45 

## 📌 개요

클라이언트 애플리케이션 내에 사용자가 특정 장소에 대하여 즐겨찾기 기능을
사용할 수 있도록 개발된 만큼 서버 측에서도 해당 기능을 실제로 이용 할 수 있도록 
관련 APIs(즐겨찾기 리스트 `생성/조회/삭제/수정`)를 추가하였습니다.

## 👩‍💻 작업 사항

- DB 내 `bookmarks` collection 추가
- `bookmarks`에 대한 model 및 route 추가
- `즐겨찾기 리스트` (생성/조회/삭제/수정)에 대한 APIs 추가
- 타 route 파일 내 일부 변수 상수화
- 일부 APIs response 코드에 대한 return문 추가

## ✅ 참고 사항

없습니다
