### PR TITLE
[refactor]: 다중 try-catch 구문 간략화 및 swagger-doc 문서 정정 (#65)

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -40,7 +40,7 @@ const createHashedPassword = (password) => {
  *               type: string
  *               example: "User with this email already exists"
  *       409:
- *         description: Bad Request
+ *         description: Conflict
  *         schema:
  *           type: object
  *           properties:

--- a/routes/markers.js
+++ b/routes/markers.js
@@ -14,6 +14,7 @@ const router = express.Router();
  *     properties:
  *       _id:
  *         type: string
+ *         format: ObjectId
  *         description: markerId
  *       latitude:
  *         type: string

--- a/routes/middlewares/authorization.js
+++ b/routes/middlewares/authorization.js
@@ -1,5 +1,6 @@
 const jwt = require('jsonwebtoken');
 require('dotenv').config();
+
 const verifyToken = (req, res, next) => {
   try {
     const userAgent = req.headers['user-agent'];

--- a/routes/users.js
+++ b/routes/users.js
@@ -13,6 +13,7 @@ const getUserInfo = async (req, res, next) => {
   let userId = req.params.id;
   if (!userId) userId = res.locals.sub;
 
+  if (!userId) return res.status(400).json({ error: 'Bad Request' });
   if (!mongoose.Types.ObjectId.isValid(userId))
     return res.status(415).json({ error: 'Unsupported Media Type' });
 
@@ -51,6 +52,14 @@ const getUserInfo = async (req, res, next) => {
  *              type: string
  *            role:
  *              type: string
+ *      400:
+ *        description: Bad Request
+ *        schema:
+ *          type: object
+ *          properties:
+ *            error:
+ *              type: string
+ *              example: "Bad Request"
  *      401:
  *        description: Unauthorized
  *        schema:


### PR DESCRIPTION
## 👀 이슈

resolve #65 

## 📌 개요

현재 서버 측에 추가된 여러 API 구성 코드 중에서 동일 동작에 대해 `try-catch` 구문이
중첩 혹은 여럿으로 나뉘어 쓰이는 부분들을 하나로 간략화하여 코드의 가독성을 향상시키고자
하였고, 그에 따라 변수로 사용되던 일부 데이터들에 대하여 상수화를 진행하고자 하였습니다.
추가적으로, 현재까지 추가된 APIs 스펙에 대해 `swagger-doc` 상호 간에 일치하지 않는
부분들이 확인되어 해당 부분까지 함께 정정하였습니다.

## 👩‍💻 작업 사항

- `auth, headcounts, markers, places, users` 라우터 코드

## ✅ 참고 사항

없습니다
