### PR TITLE
[feat]: filterAndSortByCreatedTime 미들웨어 추가 (#71)

### DIFF
--- a/routes/bookmarks.js
+++ b/routes/bookmarks.js
@@ -100,7 +100,7 @@ const getPlace = async (req, res, next) => {
   }
 };
 
-// Reqeust Query에 담긴 placeId(s)를 통해 해당 장소의 정보가 담긴 배열을 반환
+// :id값에 따른 document 중 bookarmkId값이 :id와 동일한 document 설정 및 조회
 const getPlacesInformations = async (req, res, next) => {
   const bookmarkId = req.params.id;
 


### PR DESCRIPTION
## 👀 이슈

resolve #71 

## 📌 개요

기존 `headcounts` 라우터 코드 중 인자로 들어온 배열의 각 요소인 Object에
`updateElapsedTime` 속성을 기준에 맞게 추가하는 `addUpdateElapsedTimeProp`
미들웨어가 있었는데, 클라이언트 측에서 애플리케이션 실행 후 카카오맵을 처음 확인하게
되었을 때 동일한 위도, 경도를 가리키는 장소에 대해서 복수의 마커가 생성되는 문제가 있어
동일한 위치를 가리키는 장소는 하나의 마커로 그룹화 될 수 있게끔 하고자 해당 기능을 수행하는
미들웨어를 추가하였습니다.

## 👩‍💻 작업 사항

- `filterAndSortByCreatedTime` 미들웨어 추가
> 동일한 위치를 가리키는 장소를 하나의 마커로 그룹화한 후 최신 `createdTime` 값을 지닌 Object를
기준으로 정렬 기능 수행
> `getPlacesInformations` 미들웨어 설명 주석 본문 수정

## ✅ 참고 사항

없습니다
