### PR TITLE
[fix]: headcounts 라우터 내 미사용 API 코드 제거 및 특정 마커 위치에 대한 장소 정보 및 인원수 세부 정보 반환 API, getPlaceInformations 미들웨어 수정 (#77)

### DIFF
--- a/models/headcount.js
+++ b/models/headcount.js
@@ -5,6 +5,7 @@ const headcountSchema = new Schema({
   placeId: { type: Schema.Types.ObjectId, ref: 'places' },
   headcount: Number,
   createdTime: String,
+  userId: { type: Schema.Types.ObjectId, ref: 'user_infos' },
 });
 
 const Headcount = mongoose.model('headcounts', headcountSchema);


### PR DESCRIPTION
## 👀 이슈

resolve #77 

## 📌 개요

`특정 장소에 대한 인원수 등록` API 사용 시 인원수 정보를 등록한 사용자의
정보를 알 수 있도록 하고자 `headcounts` collection model에 대해서 `userId` 속성을
추가하고자 하였고, 기존 `headcounts` 라우터 내 미사용 API에 대해서 이를 제거하고,
`특정 마커 위치에 대한 장소 정보 및 인원수 세부 정보 반환 API`, `getPlaceInformations`
미들웨어를 수정하였습니다.

## 👩‍💻 작업 사항

- `headcounts` collection model에 대해 `userId` 속성 추가
- `headcounts` 라우터 내 미사용 API 제거
- `특정 마커 위치에 대한 장소 정보 및 인원수 세부 정보 반환 API` 로직 수정
- `getPlaceInformations` 미들웨어 수정

## ✅ 참고 사항

- 기존 `headcounts` collection model 구조

<img width="447" alt="1" src="https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/20682777-718c-4db5-a49e-859df3d1ab0c">

- `userId` 속성 추가 후 `headcounts` collection model 구조

<img width="356" alt="2" src="https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/759e13a7-46ae-4e51-ab66-406b8801a29f">