### PR TITLE
[fix]: '신규 장소 등록' API 로직 수정 (#81)

### DIFF
--- a/routes/places.js
+++ b/routes/places.js
@@ -203,6 +203,7 @@ router.post('/private', verifyToken, async (req, res) => {
       placeId: newPlace._id,
       headcount: -1,
       createdTime: getFormattedDate(),
+      userId: res.locals.sub,
     });
 
     const newHeadcount = await headcount.save();


### PR DESCRIPTION
## 👀 이슈

resolve #81 

## 📌 개요

`신규 장소 등록` API 사용으로 인해 `headcounts` collection 내에 신규
document가 추가될 때 `userId`도 함께 기록될 수 있도록 하기 위해
`신규 장소 등록` API의 로직을 수정하였습니다.

## 👩‍💻 작업 사항

- `신규 장소 등록` API 로직 수정

## ✅ 참고 사항

없습니다
