### PR TITLE
[fix]: 'addUpdateElapsedTimeProp' 미들웨어 로직 수정 (#83)

### DIFF
--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -106,7 +106,7 @@ const addUpdateElapsedTimeProp = (currPlaceInformations) => {
     const latestInfo = group[0];
     const elapsedTime =
       group.length > 1
-        ? Math.floor((currentTime - new Date(group[1].createdTime)) / 1000)
+        ? Math.floor((currentTime - new Date(latestInfo.createdTime)) / 1000)
         : -1;
 
     let updatedInfo = latestInfo.toObject();


### PR DESCRIPTION
## 👀 이슈

resolve #83 

## 📌 개요

`addUpdateElapsedTimeProp` 미들웨어 코드 중
`elapsedTime(장소 추가 후 현재까지 경과시간)` 값을 구하는 로직 내
문제가 있어 올바르게 수정하였습니다.

## 👩‍💻 작업 사항

- `headcounts` 라우터 내 `addUpdateElapsedTimeProp` 미들웨어 `elapsedTime` 로직 수정

## ✅ 참고 사항

없습니다
