### PR TITLE
Fix/95

### DIFF
--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -222,7 +222,7 @@ router.get('/public/placeInformations', async (req, res) => {
         populate: { path: 'markerId' },
       })
       .exec();
-    if (!placeInformations) {
+    if (placeInformations.length === 0) {
       return res.status(404).json({ error: 'Not Found' });
     }
 
@@ -238,7 +238,7 @@ router.get('/public/placeInformations', async (req, res) => {
 
 /**
  * @swagger
- * /api/headcounts/public/{markerId}/placeInformations:
+ * /api/headcounts/public/placeInformations/markers/{markerId}:
  *   get:
  *     tags:
  *       - Headcounts Collection 기반 API
@@ -326,32 +326,38 @@ router.get('/public/placeInformations', async (req, res) => {
  *               type: string
  *               example: "Internal Server Error"
  */
-router.get('/public/:id/placeInformations', getMarker, async (req, res) => {
-  try {
-    const markerId = req.params.id;
-    const placeInformations = await Headcount.find()
-      .populate({
-        path: 'placeId',
-        populate: { path: 'markerId' },
-      })
-      .exec();
-    if (!placeInformations) return res.status(404).json({ error: 'Not Found' });
+router.get(
+  '/public/placeInformations/markers/:id',
+  getMarker,
+  async (req, res) => {
+    try {
+      const markerId = req.params.id;
+      const placeInformations = await Headcount.find()
+        .populate({
+          path: 'placeId',
+          populate: { path: 'markerId' },
+        })
+        .exec();
 
-    const filteredPlaceInformations = placeInformations.filter(
-      (placeInfo) => placeInfo.placeId.markerId._id.toString() === markerId
-    );
-    const updatedPlaceInformations = addUpdateElapsedTimeProp(
-      filteredPlaceInformations
-    );
-    return res.status(200).json(updatedPlaceInformations);
-  } catch (err) {
-    return res.status(500).json({ error: err.message });
+      if (placeInformations.length === 0)
+        return res.status(404).json({ error: 'Not Found' });
+
+      const filteredPlaceInformations = placeInformations.filter(
+        (placeInfo) => placeInfo.placeId.markerId._id.toString() === markerId
+      );
+      const updatedPlaceInformations = addUpdateElapsedTimeProp(
+        filteredPlaceInformations
+      );
+      return res.status(200).json(updatedPlaceInformations);
+    } catch (err) {
+      return res.status(500).json({ error: err.message });
+    }
   }
-});
+);
 
 /**
  * @swagger
- * /api/headcounts/private/{placeId}:
+ * /api/headcounts/private/places/{placeId}:
  *   post:
  *     tags:
  *       - Headcounts Collection 기반 API
@@ -427,7 +433,7 @@ router.get('/public/:id/placeInformations', getMarker, async (req, res) => {
  *               type: string
  *               example: "Internal Server Error"
  */
-router.post('/private/:id', verifyToken, getPlace, async (req, res) => {
+router.post('/private/places/:id', verifyToken, getPlace, async (req, res) => {
   if (
     (!req.body.headcount && req.body.headcount < 0) ||
     typeof req.body.headcount !== 'number'

--- a/routes/places.js
+++ b/routes/places.js
@@ -173,7 +173,7 @@ router.post('/private', verifyToken, async (req, res) => {
 
 /**
  * @swagger
- * /api/places/private/{placeId}:
+ * /api/places/private/places/{placeId}:
  *   put:
  *     tags:
  *       - Places Collection 기반 API
@@ -239,7 +239,7 @@ router.post('/private', verifyToken, async (req, res) => {
  *               type: string
  *               example: "Internal Server Error"
  */
-router.put('/private/:id', verifyToken, getPlace, async (req, res) => {
+router.put('/private/places/:id', verifyToken, getPlace, async (req, res) => {
   const { placeName, detailAddress } = req.body;
   if (!placeName || !detailAddress)
     return res.status(400).json({ error: 'Bad Request' });
@@ -257,7 +257,7 @@ router.put('/private/:id', verifyToken, getPlace, async (req, res) => {
 
 /**
  * @swagger
- * /api/places/private/{placeId}:
+ * /api/places/private/places/{placeId}:
  *   delete:
  *     tags:
  *       - Places Collection 기반 API
@@ -313,24 +313,29 @@ router.put('/private/:id', verifyToken, getPlace, async (req, res) => {
  *               type: string
  *               example: "Internal Server Error"
  */
-router.delete('/private/:id', verifyToken, getPlace, async (req, res) => {
-  try {
-    const places = await Place.find({
-      markerId: res.place.markerId,
-    });
-    // 삭제하려는 장소 위치(위도, 경도)에 등록된 장소가 한 곳 일 때 마커 데이터도 함께 제거
-    if (places.length === 1) {
-      // markers collection 내 삭제하려는 장소의 _id값을 지닌 연관 document 제거
-      await Marker.deleteOne({ _id: res.place.markerId });
-    }
+router.delete(
+  '/private/places/:id',
+  verifyToken,
+  getPlace,
+  async (req, res) => {
+    try {
+      const places = await Place.find({
+        markerId: res.place.markerId,
+      });
+      // 삭제하려는 장소 위치(위도, 경도)에 등록된 장소가 한 곳 일 때 마커 데이터도 함께 제거
+      if (places.length === 1) {
+        // markers collection 내 삭제하려는 장소의 _id값을 지닌 연관 document 제거
+        await Marker.deleteOne({ _id: res.place.markerId });
+      }
 
-    // (headcounts) collection 내 삭제하려는 장소의 _id값을 지닌 연관 document(들) 일괄 제거
-    await Headcount.deleteMany({ placeId: res.place._id });
-    await res.place.deleteOne();
-    return res.status(200).json({ remainingPlacesCnt: places.length - 1 });
-  } catch (err) {
-    return res.status(500).json({ error: err.message });
+      // (headcounts) collection 내 삭제하려는 장소의 _id값을 지닌 연관 document(들) 일괄 제거
+      await Headcount.deleteMany({ placeId: res.place._id });
+      await res.place.deleteOne();
+      return res.status(200).json({ remainingPlacesCnt: places.length - 1 });
+    } catch (err) {
+      return res.status(500).json({ error: err.message });
+    }
   }
-});
+);
 
 module.exports = router;


### PR DESCRIPTION
## 👀 이슈

resolve #95 

## 📌 개요

`bookmarks, headcounts, places` 라우터 내 `:id` `Path`를 사용하는 APIs 들에
대하여 확실하게 엔드포인트를 구별할 수 있도록 하고자 `:id` 이전에 어떤 id에 대한 값인지
구별하는 엔드포인트 단어를 모든 APIs에 누락없이 추가하였고, API 내에서 find 함수를
통해 DB collection 내에서 특정 document(s)를 찾는 로직에 대해서 매핑되는 데이터를 조회하지
못 하였을 경우 `404`에러가 예외 없이 응답으로 나타나게끔 기존 로직을 수정하였습니다.

## 👩‍💻 작업 사항

- `bookmarks` 라우터 내 일부 API 엔드포인트 변경 및 `404` 에러 작동 로직 활성화
- `headcounts` 라우터 내 일부 API 엔드포인트 변경 및 `404` 에러 작동 로직 활성화
- `places` 라우터 내 일부 API 엔드포인트 변경 및 `404` 에러 작동 로직 활성화

## ✅ 참고 사항

없습니다
