### PR TITLE
[feat]: `임시 비밀번호 생성` API 추가 (#101)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "jsonwebtoken": "^9.0.1",
         "mongoose": "^7.2.1",
         "morgan": "^1.10.0",
+        "nodemailer": "^6.9.4",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^4.6.3",
         "winston": "^3.10.0"
@@ -1138,6 +1139,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.4.tgz",
+      "integrity": "sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -2729,6 +2738,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "nodemailer": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.4.tgz",
+      "integrity": "sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA=="
     },
     "nodemon": {
       "version": "2.0.22",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "jsonwebtoken": "^9.0.1",
     "mongoose": "^7.2.1",
     "morgan": "^1.10.0",
+    "nodemailer": "^6.9.4",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^4.6.3",
     "winston": "^3.10.0"


### PR DESCRIPTION
## 👀 이슈

resolve #101 

## 📌 개요

사용자가 회원가입한 계정의 비밀번호를 기억하지 못 할 때
가입 메일로 임시 비밀번호를 전송하여 회원 정보를 찾을 수 있도록
하는 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- `임시 비밀번호 생성` API 추가
> <picture>
>   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/main/blockquotes/badge/light-theme/note.svg">
>   <img alt="Note" src="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/main/blockquotes/badge/dark-theme/note.svg">
> </picture><br>
> Note (`users` collection 관련 APIs)
1. _**[POST]**_ **`/user/generate-temp-password`** API 추가 **➔** 회원의 기존 비밀번호 대신 임시 비밀번호로 변경되며, 요청된 이메일 주소로 임시 비밀번호를 발송합니다.

## ✅ 참고 사항

- `임시 비밀번호 생성` API 사용 후
>  요청 메일 주소로 임시 비밀번호가 발송된 메일 화면

![Screenshot 2023-09-06 at 1 17 52 AM](https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/f3122b8f-d996-441a-9482-d2acb69114c6)