### PR TITLE
[feat]: `장소 검색 기록 관련` APIs 추가 (#105)

### DIFF
--- a/models/bookmark.js
+++ b/models/bookmark.js
@@ -14,4 +14,5 @@ const bookmarkSchema = new Schema({
 });
 
 const Bookmark = mongoose.model('bookmarks', bookmarkSchema);
+
 module.exports = Bookmark;

--- a/models/searchHistory.js
+++ b/models/searchHistory.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const searchHistorySchema = new mongoose.Schema({
+  searchKeyword: String,
+  latitude: String,
+  longitude: String,
+  userId: { type: Schema.Types.ObjectId, ref: 'user_infos' },
+});
+
+const SearchHistory = mongoose.model('search_history', searchHistorySchema);
+
+module.exports = SearchHistory;

--- a/routes/bookmarks.js
+++ b/routes/bookmarks.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const Bookmark = require('../models/bookmark');
-const UserInfo = require('../models/user_info');
 const Place = require('../models/place');
 const Headcount = require('../models/headcount');
 const { verifyToken } = require('./middlewares/authorization');
@@ -17,6 +16,7 @@ const router = express.Router();
  *       - userId
  *       - bookmarkName
  *       - iconColor
+ *       - __v
  *     properties:
  *       _id:
  *         type: string
@@ -157,14 +157,6 @@ const addUpdateElapsedTimeProp = (currPlaceInformations) => {
  *         schema:
  *           items:
  *             $ref: '#/definitions/Bookmark'
- *       400:
- *         description: Bad Request
- *         schema:
- *           type: object
- *           properties:
- *             error:
- *               type: string
- *               example: "Bad Request"
  *       401:
  *         description: Unauthorized
  *         schema:
@@ -181,14 +173,6 @@ const addUpdateElapsedTimeProp = (currPlaceInformations) => {
  *             error:
  *               type: string
  *               example: "Not Found"
- *       415:
- *         description: Unsupported Media Type
- *         schema:
- *           type: object
- *           properties:
- *             error:
- *               type: string
- *               example: "Unsupported Media Type"
  *       500:
  *         description: Internal Server Error
  *         schema:
@@ -771,7 +755,7 @@ router.patch(
  *           type: object
  *           properties:
  *             error:
- *               type: number
+ *               type: string
  *               example: "Unauthorized"
  *       404:
  *         description: Not Found

--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -18,6 +18,7 @@ const router = express.Router();
  *       - headcount
  *       - createdTime
  *       - userId
+ *       - __v
  *     properties:
  *       _id:
  *         type: string

--- a/routes/markers.js
+++ b/routes/markers.js
@@ -11,6 +11,7 @@ const router = express.Router();
  *       - _id
  *       - latitude
  *       - longitude
+ *       - __v
  *     properties:
  *       _id:
  *         type: string

--- a/routes/places.js
+++ b/routes/places.js
@@ -18,6 +18,7 @@ const router = express.Router();
  *       - address
  *       - detailAddress
  *       - markerId
+ *       - __v
  *     properties:
  *       _id:
  *         type: string
@@ -294,7 +295,7 @@ router.put('/private/places/:id', verifyToken, getPlace, async (req, res) => {
  *           type: object
  *           properties:
  *             error:
- *               type: number
+ *               type: string
  *               example: "Unauthorized"
  *       415:
  *         description: Unsupported Media Type

--- a/routes/searchHistories.js
+++ b/routes/searchHistories.js
@@ -1,0 +1,282 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const SearchHistory = require('../models/searchHistory');
+const { verifyToken } = require('./middlewares/authorization');
+const router = express.Router();
+
+/** ⚙️ [searchHistory] collection에 대한 Model definition
+ * @swagger
+ * definitions:
+ *   SearchHistory:
+ *     type: object
+ *     required:
+ *       - _id
+ *       - searchKeyword
+ *       - latitude
+ *       - longitude
+ *       - userId
+ *       - __v
+ *     properties:
+ *       _id:
+ *         type: string
+ *         format: ObjectId
+ *         description: searchHistoryId
+ *       searchKeyword:
+ *         type: string
+ *         description: 검색하여 선택한 키워드
+ *       latitude:
+ *         type: string
+ *         description: 검색하여 선택한 장소의 위도
+ *       longitude:
+ *         type: string
+ *         description: 검색하여 선택한 장소의 경도
+ *       userId:
+ *         type: string
+ *         format: ObjectId
+ *         description: searchHistoryId와 연관된 userId
+ *       __v:
+ *         type: number
+ *         description: version key
+ */
+
+const getSearchHistory = async (req, res, next) => {
+  const searchHistoryId = req.params.id;
+
+  if (!searchHistoryId) return res.status(400).json({ error: 'Bad Request' });
+  if (!mongoose.Types.ObjectId.isValid(searchHistoryId))
+    return res.status(415).json({ error: 'Unsupported Media Type' });
+
+  try {
+    const searchHistory = await SearchHistory.findById(searchHistoryId);
+    if (!searchHistory) return res.status(404).json({ error: 'Not Found' });
+
+    res.searchHistory = searchHistory;
+    next();
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+};
+
+/**
+ * @swagger
+ * /api/search-histories/private:
+ *   get:
+ *     tags:
+ *       - SearchHistory Collection 기반 API
+ *     summary: 검색하여 선택했던 장소 목록 반환
+ *     security:
+ *       - JWT: []
+ *     description: (search_history) collection 내에서 사용자가 검색하여 선택했던 장소 목록을 반환합니다.
+ *     responses:
+ *       200:
+ *         description: OK
+ *         schema:
+ *           items:
+ *             $ref: '#/definitions/SearchHistory'
+ *       401:
+ *         description: Unauthorized
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unauthorized"
+ *       404:
+ *         description: Not Found
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Not Found"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
+router.get('/private', verifyToken, async (req, res) => {
+  const userId = res.locals.sub;
+
+  try {
+    const searchHistories = await SearchHistory.find({ userId });
+    if (searchHistories.length === 0)
+      return res.status(404).json({ error: 'Not Found' });
+
+    return res.status(200).json(searchHistories);
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * @swagger
+ * /api/search-histories/private:
+ *   post:
+ *     tags:
+ *       - SearchHistory Collection 기반 API
+ *     summary: 검색하여 선택했던 장소 정보 등록
+ *     security:
+ *       - JWT: []
+ *     description: 사용자가 검색 후 선택한 장소 정보를 등록합니다.
+ *     parameters:
+ *       - in: body
+ *         name: searchHistoryRequest
+ *         required: true
+ *         schema:
+ *           type: object
+ *           properties:
+ *             searchKeyword:
+ *               type: string
+ *             latitude:
+ *               type: string
+ *             longitude:
+ *               type: string
+ *     responses:
+ *       201:
+ *         description: Created
+ *         schema:
+ *           $ref: '#/definitions/SearchHistory'
+ *       400:
+ *         description: Bad Request
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Bad Request"
+ *       401:
+ *         description: Unauthorized
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unauthorized"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
+router.post('/private', verifyToken, async (req, res) => {
+  const { searchKeyword, latitude, longitude } = req.body;
+
+  if (!searchKeyword || !latitude || !longitude)
+    return res.status(400).json({ error: 'Bad Request' });
+
+  const userId = res.locals.sub;
+
+  try {
+    // /** 동일한 searchKeyword, latitude, longitude, userId를 가진 document가
+    // 있는지 확인 후 해당 document 제거 */
+    await SearchHistory.findOneAndDelete({
+      searchKeyword,
+      latitude,
+      longitude,
+      userId,
+    });
+
+    const searchHistory = new SearchHistory(req.body);
+
+    searchHistory.userId = userId;
+
+    const newSearchHistory = await searchHistory.save();
+    return res.status(201).json(newSearchHistory);
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * @swagger
+ * /api/search-histories/private/{searchHistoryId}:
+ *   delete:
+ *     tags:
+ *       - SearchHistory Collection 기반 API
+ *     summary: 검색하여 선택했던 장소 정보 제거
+ *     security:
+ *       - JWT: []
+ *     description: 사용자가 검색 후 선택하여 저장된 장소 정보 기록을 제거합니다.
+ *     parameters:
+ *       - in: path
+ *         name: searchHistoryId
+ *         required: true
+ *         description: searchHistoryId
+ *         type: string
+ *     responses:
+ *       200:
+ *         description: OK
+ *         schema:
+ *           type: object
+ *           properties:
+ *             message:
+ *               type: string
+ *               example: "OK"
+ *       400:
+ *         description: Bad Request
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Bad Request"
+ *       401:
+ *         description: Unauthorized
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unauthorized"
+ *       404:
+ *         description: Not Found
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Not Found"
+ *       415:
+ *         description: Unsupported Media Type
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Unsupported Media Type"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
+router.delete(
+  '/private/:id',
+  verifyToken,
+  getSearchHistory,
+  async (req, res) => {
+    try {
+      const result = await SearchHistory.findByIdAndDelete(
+        res.searchHistory._id
+      );
+
+      if (!result) return res.status(404).json({ error: 'Not Found' });
+
+      res.status(200).json({ message: 'OK' });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  }
+);
+
+module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -19,6 +19,7 @@ const router = express.Router();
  *       - username
  *       - role
  *       - point
+ *       - __v
  *     properties:
  *       _id:
  *         type: string

--- a/server.js
+++ b/server.js
@@ -95,6 +95,10 @@ app.use('/api/markers', markerRouter);
 const bookmarkRouter = require('./routes/bookmarks');
 app.use('/api/bookmarks', bookmarkRouter);
 
+// [search_history] collection에 대한 router 등록
+const searchHistoryRouter = require('./routes/searchHistories');
+app.use('/api/search-histories', searchHistoryRouter);
+
 app.listen(port, () => {
   console.log('Server started on port 5050');
 });


### PR DESCRIPTION
## 👀 이슈

resolve #105 

## 📌 개요

애플리케이션 내에서 회원 사용자가 특정 장소명을 키워드로 사용하여
장소 검색 시 이에 대한 기록을 남길 수 있도록 `장소 검색 정보` 조회/등록/삭제
API를 일괄적으로 추가하였습니다.

## 👩‍💻 작업 사항

> <picture>
>   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/main/blockquotes/badge/light-theme/note.svg">
>   <img alt="Note" src="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/main/blockquotes/badge/dark-theme/note.svg">
> </picture><br>
> Note (`users` collection 관련 APIs)
1. _**[GET]**_ **`/search-histories/private`** API 추가 **➔** (search_history) collection 내에서 사용자가 검색하여 선택했던 장소 목록을 반환합니다.
2. _**[POST]**_ **`/search-histories/private`** API 추가 **➔** 사용자가 검색 후 선택한 장소 정보를 등록합니다.
3. _**[DELETE]**_ **`/search-histories/private/{searchHistoryId}`** API 추가 **➔** 사용자가 검색 후 선택하여 저장된 장소 정보 기록을 제거합니다.
- `search_history` collection에 대한 스키마 모델 파일 추가
- 일부 APIs `swagger-doc` 정정

## ✅ 참고 사항

- `search_history` collection에 대한 스키마

![Screenshot 2023-09-09 at 1 57 48 PM](https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/554569a2-38bb-4a39-9d41-60dfa3586636)

- 추가된 APIs에 대한 `swagger-doc`

![Screenshot 2023-09-09 at 1 59 49 PM](https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/eaa90ca3-01bb-4fd5-9da7-1a095bc1d5d6)