### PR TITLE
[fix]: search_history collection 스키마 내 createdTime 속성 추가 (#107)

### DIFF
--- a/models/searchHistory.js
+++ b/models/searchHistory.js
@@ -5,6 +5,7 @@ const searchHistorySchema = new mongoose.Schema({
   searchKeyword: String,
   latitude: String,
   longitude: String,
+  createdTime: String,
   userId: { type: Schema.Types.ObjectId, ref: 'user_infos' },
 });
 


### PR DESCRIPTION
## 👀 이슈

resolve #107 

## 📌 개요

`search_history` collection 내에서 조회되는 데이터를 현재 년도 기준으로만
필터링할 수 있도록 기존 스키마에 `createdTime` 속성을 추가하였습니다.

## 👩‍💻 작업 사항

- `search_history` collection에 대한 스키마 모델 파일 내 `createdTime` 속성 추가
- `검색하여 선택했던 장소 목록 반환` API 구성 코드 내 `createdTime` 속성 추가 및 작년
document(s) 삭제 로직 추가

## ✅ 참고 사항

없습니다
