### PR TITLE
[fix]: '검색하여 선택했던 장소 목록 반환' API 데이터 조회 순서 변경 (#110)

### DIFF
--- a/routes/searchHistories.js
+++ b/routes/searchHistories.js
@@ -119,16 +119,16 @@ router.get('/private', verifyToken, async (req, res) => {
       },
     });
 
-    console.log('작년 데이터:', lastYearHistories);
-
     // 작년 데이터 삭제
     if (lastYearHistories.length > 0) {
       const idsToDelete = lastYearHistories.map((history) => history._id);
       await SearchHistory.deleteMany({ _id: { $in: idsToDelete } });
     }
 
-    // 남아 있는 데이터 조회
-    const searchHistories = await SearchHistory.find({ userId });
+    // 남아 있는 데이터를 createdTime 필드 기준 최신 데이터부터 조회
+    const searchHistories = await SearchHistory.find({ userId }).sort({
+      createdTime: -1,
+    });
     if (searchHistories.length === 0)
       return res.status(404).json({ error: 'Not Found' });
 


### PR DESCRIPTION
## 👀 이슈

resolve #110 

## 📌 개요

기존 `검색하여 선택했던 장소 목록 반환` API 사용 시 데이터 조회 순서는
`search_history` collection에 추가된 document들의 순서대로 조회되었는데,
`createdTime` 속성의 값이 최신인 데이터들부터 조회되도록 관련 로직을 추가하였습니다.

## 👩‍💻 작업 사항

- `검색하여 선택했던 장소 목록 반환` API 내에 데이터 조회 정렬 순서 변경 로직 추가

## ✅ 참고 사항

없습니다
