### PR TITLE
[feat]: `회원 탈퇴 및 사유 기록` API 추가 (#109)

### DIFF
--- a/models/headcount.js
+++ b/models/headcount.js
@@ -5,7 +5,6 @@ const headcountSchema = new Schema({
   placeId: { type: Schema.Types.ObjectId, ref: 'places' },
   headcount: Number,
   createdTime: String,
-  userId: { type: Schema.Types.ObjectId, ref: 'user_infos' },
 });
 
 const Headcount = mongoose.model('headcounts', headcountSchema);

--- a/models/userWithdrawalReasons.js
+++ b/models/userWithdrawalReasons.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const userWithdrawalReasonsSchema = new mongoose.Schema({
+  withdrawalReason: String,
+  feedback: String,
+  createdTime: String,
+});
+
+const UserWithdrawalReason = mongoose.model(
+  'user_withdrawal_reasons',
+  userWithdrawalReasonsSchema
+);
+
+module.exports = UserWithdrawalReason;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,7 +1,12 @@
 const express = require('express');
 const UserInfo = require('../models/user_info');
+const Bookmark = require('../models/bookmark');
+const SearchHistory = require('../models/searchHistory');
+const UserWithdrawalReason = require('../models/userWithdrawalReasons');
 const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
+const { verifyToken } = require('./middlewares/authorization');
+const { getFormattedDate } = require('../utils/dateUtils');
 require('dotenv').config();
 const router = express.Router();
 
@@ -245,6 +250,93 @@ router.post('/public/sign-up', async (req, res) => {
 
     const newUser = await new UserInfo(user).save();
     return res.status(201).json(newUser);
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * @swagger
+ * /api/auth/private/delete-account:
+ *   delete:
+ *     tags:
+ *       - 회원 인증 API
+ *     summary: 회원 탈퇴
+ *     description: 인증된 사용자의 계정을 삭제합니다.
+ *     parameters:
+ *       - in: body
+ *         name: deleteAccountRequest
+ *         description: deleteAccountRequest
+ *         required: true
+ *         schema:
+ *           type: object
+ *           properties:
+ *             withdrawalReason:
+ *               type: string
+ *             feedback:
+ *               type: string
+ *     security:
+ *       - JWT: []
+ *     responses:
+ *       200:
+ *         description: OK
+ *         schema:
+ *           type: object
+ *           properties:
+ *             message:
+ *               type: string
+ *               example: "Account deleted successfully"
+ *       401:
+ *         description: Unauthorized
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Invalid token"
+ *       500:
+ *         description: Internal Server Error
+ *         schema:
+ *           type: object
+ *           properties:
+ *             error:
+ *               type: string
+ *               example: "Internal Server Error"
+ */
+router.delete('/private/delete-account', verifyToken, async (req, res) => {
+  const userId = res.locals.sub;
+
+  const { withdrawalReason, feedback } = req.body;
+
+  if (!withdrawalReason || !feedback) {
+    return res.status(400).json({ error: 'Bad request' });
+  }
+
+  try {
+    await UserInfo.findByIdAndDelete(userId);
+
+    /** 'bookmarks/search_histories' collection
+     * 내에 동일한 userId를 가진 document(s)가 있는지 확인 후 해당
+     * document(s) 제거 */
+    await Bookmark.deleteMany({
+      userId,
+    });
+
+    await SearchHistory.deleteMany({
+      userId,
+    });
+
+    const userWithdrawalReason = new UserWithdrawalReason({
+      withdrawalReason,
+      feedback,
+      createdTime: getFormattedDate(),
+    });
+
+    const newUserWithdrawalReason = await new UserWithdrawalReason(
+      userWithdrawalReason
+    ).save();
+
+    return res.status(200).json({ message: 'Account deleted successfully' });
   } catch (err) {
     return res.status(500).json({ error: err.message });
   }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -19,6 +19,28 @@ const createHashedPassword = (password) => {
   return crypto.createHash('sha512').update(password).digest('base64');
 };
 
+/** ⚙️ [userWithdrawalReasons] collection에 대한 Model definition
+ * @swagger
+ * definitions:
+ *   UserWithdrawalReason:
+ *     type: object
+ *     required:
+ *       - withdrawalReason
+ *       - feedback
+ *       - createdTime
+ *     properties:
+ *       withdrawalReason:
+ *         type: string
+ *         description: 회원탈퇴의 주된 사유
+ *       feedback:
+ *         type: string
+ *         description: 회원탈퇴 시 제출된 추가 의견 또는 피드백
+ *       createdTime:
+ *         type: string
+ *         example: "2023-09-11 20:44:51.681"
+ *         description: 회원탈퇴 사유 데이터가 추가된 일자 및 시각
+ */
+
 /**
  * @swagger
  * /api/auth/public/search:
@@ -261,8 +283,8 @@ router.post('/public/sign-up', async (req, res) => {
  *   delete:
  *     tags:
  *       - 회원 인증 API
- *     summary: 회원 탈퇴
- *     description: 인증된 사용자의 계정을 삭제합니다.
+ *     summary: 회원 탈퇴 및 사유 기록
+ *     description: 인증된 사용자의 계정을 삭제하며, 사유를 기록합니다.
  *     parameters:
  *       - in: body
  *         name: deleteAccountRequest

--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -17,7 +17,6 @@ const router = express.Router();
  *       - placeId
  *       - headcount
  *       - createdTime
- *       - userId
  *       - __v
  *     properties:
  *       _id:
@@ -35,10 +34,6 @@ const router = express.Router();
  *         type: string
  *         example: "2023-07-29 20:44:51.681"
  *         description: 인원수 정보가 추가된 일자 및 시각
- *       userId:
- *         type: string
- *         format: ObjectId
- *         description: headcountId와 연관된 userId
  *       __v:
  *         type: number
  *         description: version key
@@ -397,8 +392,6 @@ router.get(
  *             createdTime:
  *               type: string
  *               example: "2023-07-29 20:44:51.681"
- *             userId:
- *               type: string
  *             __v:
  *               type: number
  *       400:
@@ -444,7 +437,6 @@ router.post('/private/places/:id', verifyToken, getPlace, async (req, res) => {
   const headcount = new Headcount(req.body);
   headcount.placeId = req.params.id;
   headcount.createdTime = getFormattedDate();
-  headcount.userId = res.locals.sub;
 
   try {
     const newHeadcount = await headcount.save();

--- a/routes/places.js
+++ b/routes/places.js
@@ -162,7 +162,6 @@ router.post('/private', verifyToken, async (req, res) => {
       placeId: newPlace._id,
       headcount: -1,
       createdTime: getFormattedDate(),
-      userId: res.locals.sub,
     });
 
     const newHeadcount = await headcount.save();


### PR DESCRIPTION
## 👀 이슈

resolve #109

## 📌 개요

회원가입한 회원이 서비스에서 본인의 정보를 원하는 때에 지울 수 있도록
하고자 `회원 탈퇴 및 사유 기록` API를 추가하였습니다.

## 👩‍💻 작업 사항

- `회원 탈퇴 및 사유 기록` API 추가
> <picture>
>   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/main/blockquotes/badge/light-theme/note.svg">
>   <img alt="Note" src="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/main/blockquotes/badge/dark-theme/note.svg">
> </picture><br>
> Note (`users/user_withdrawal_reasons` collection 관련 APIs)
1. _**[POST]**_ **`/api/auth/private/delete-account`** API 추가 **➔** 인증된 사용자의 계정을 삭제하며, 사유를 기록합니다.

## ✅ 참고 사항

- `회원 탈퇴 및 사유 기록` API에 대한 **swagger-doc**
![Screenshot 2023-09-12 at 12 59 42 AM](https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/2e7e13fc-c402-4052-8739-a1e35d18f3e7)

- 추가된 `user_withdrawal_reasons` collection에 대한 스키마 모델 파일 구조

![Screenshot 2023-09-12 at 1 04 58 AM](https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/983d8817-e1ff-490e-8258-ed841d9d794f)