### PR TITLE
[fix]: httpLogger 내에 'error.log' 제거 (#113)

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,7 +36,6 @@ const httpLogger = winston.createLogger({
   level: 'info',
   format: winston.format.json(),
   transports: [
-    new winston.transports.File({ filename: 'error.log', level: 'error' }),
     new winston.transports.File({ filename: 'http.log' }),
     new winston.transports.Console({ format: winston.format.simple() }),
   ],


### PR DESCRIPTION
## 👀 이슈

resolve #113 

## 📌 개요

httpLogger 내에서 `error.log`에 대한 내용을 별도로 처리하지 않도록
하고자 관련 코드를 제거하였습니다.

## 👩‍💻 작업 사항

- httpLogger 내에 `error.log` 제거

## ✅ 참고 사항

없습니다