### PR TITLE
[FIX] `user_infos collection` 스키마 내에 `createdTime` 속성 추가 #115

### DIFF
--- a/models/user_info.js
+++ b/models/user_info.js
@@ -6,6 +6,7 @@ const userInfoSchema = new mongoose.Schema({
   username: String,
   role: String,
   point: Number,
+  createdTime: String,
 });
 
 const UserInfo = mongoose.model('user_infos', userInfoSchema);

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -225,6 +225,8 @@ router.post('/public/login', async (req, res) => {
  *               type: string
  *             point:
  *               type: number
+ *             createdTime:
+ *               type: string
  *             __v:
  *               type: number
  *       400:
@@ -268,6 +270,7 @@ router.post('/public/sign-up', async (req, res) => {
       username,
       role: 'member',
       point: 0,
+      createdTime: getFormattedDate(),
     });
 
     const newUser = await new UserInfo(user).save();

--- a/routes/users.js
+++ b/routes/users.js
@@ -40,6 +40,10 @@ const router = express.Router();
  *       point:
  *         type: number
  *         description: 포인트
+ *       createdTime:
+ *         type: string
+ *         example: "2023-07-29 20:44:51.681"
+ *         description: 유저 데이터가 추가된 일자 및 시각
  *       __v:
  *         type: number
  *         description: version key


### PR DESCRIPTION
## 👀 이슈

resolve #115 

## 📌 개요

기존 `user_infos` collection 내에 **회원가입**에 의해 신규 유저 정보가
추가되면, 해당 유저가 언제 가입했는지 확인하기 위해 서버 로그를 살펴봐야
하는 번거로움이 있어서 `createdTime` 속성을 추가하여 쉽게 파악할 수
있도록 하였습니다.

## 👩‍💻 작업 사항

- `user_infos` collection 스키마에 대한 모델 파일 내에 `createdTime` 속성 추가
- `user_infos` collection 스키마에 대한 모델 **swagger-doc** definition 수정
- `회원가입` API에 대한 **swagger-doc** http response 내에 createdTime 속성 추가

## ✅ 참고 사항

- 수정 전 `user_infos` collection 스키마 모델 구조

![1](https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/739a33ab-1590-4bf8-b361-a3b45f1629ce)

- 수정 후 `user_infos` collection 스키마 모델 구조
> **createdTime** 속성이 추가됨

![2](https://github.com/Sinabro-littlebylittle/sinabroServer/assets/56868605/be6559d2-3d8b-4c67-b61d-1f56bbd543e8)