### PR TITLE
[fix]: swagger-ui-express 패키지 버전 업데이트 (#117)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "morgan": "^1.10.0",
         "nodemailer": "^6.9.4",
         "swagger-jsdoc": "^6.2.8",
-        "swagger-ui-express": "^4.6.3",
+        "swagger-ui-express": "^5.0.0",
         "winston": "^3.10.0"
       },
       "devDependencies": {
@@ -1630,16 +1630,16 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.19.0.tgz",
-      "integrity": "sha512-9C9fJGI18gK5AhaU5YRyPY1lXJH4lmWh8h9zFMrJBkYzdRjCbAzYl1ayWPYgwFvag/Luqi3Co599OK/39IS2QQ=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.7.1.tgz",
+      "integrity": "sha512-mY+htL+asLQTrwbCOcbzOtgch2TA5A4IqMleEtVleegFAIgzd2w0jyY2IvA8upDOR/AmftudyiI1/h+VBPIc7A=="
     },
     "node_modules/swagger-ui-express": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
-      "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
       "dependencies": {
-        "swagger-ui-dist": ">=4.11.0"
+        "swagger-ui-dist": ">=5.0.0"
       },
       "engines": {
         "node": ">= v0.10.32"
@@ -3103,16 +3103,16 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.19.0.tgz",
-      "integrity": "sha512-9C9fJGI18gK5AhaU5YRyPY1lXJH4lmWh8h9zFMrJBkYzdRjCbAzYl1ayWPYgwFvag/Luqi3Co599OK/39IS2QQ=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.7.1.tgz",
+      "integrity": "sha512-mY+htL+asLQTrwbCOcbzOtgch2TA5A4IqMleEtVleegFAIgzd2w0jyY2IvA8upDOR/AmftudyiI1/h+VBPIc7A=="
     },
     "swagger-ui-express": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
-      "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
       "requires": {
-        "swagger-ui-dist": ">=4.11.0"
+        "swagger-ui-dist": ">=5.0.0"
       }
     },
     "text-hex": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "morgan": "^1.10.0",
     "nodemailer": "^6.9.4",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^4.6.3",
+    "swagger-ui-express": "^5.0.0",
     "winston": "^3.10.0"
   },
   "devDependencies": {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -311,6 +311,14 @@ router.post('/public/sign-up', async (req, res) => {
  *             message:
  *               type: string
  *               example: "Account deleted successfully"
+ *       400:
+ *         description: Bad request
+ *         schema:
+ *           type: object
+ *           properties:
+ *             errror:
+ *               type: string
+ *               example: "Bad request"
  *       401:
  *         description: Unauthorized
  *         schema:
@@ -333,9 +341,8 @@ router.delete('/private/delete-account', verifyToken, async (req, res) => {
 
   const { withdrawalReason, feedback } = req.body;
 
-  if (!withdrawalReason || !feedback) {
+  if (!withdrawalReason || !feedback)
     return res.status(400).json({ error: 'Bad request' });
-  }
 
   try {
     await UserInfo.findByIdAndDelete(userId);


### PR DESCRIPTION
## 👀 이슈

resolve #117 

## 📌 개요

기존 서버 프로젝트 내에 설치되어 있던 `swagger-ui-express` 패키지 `4.6.3` 버전에서
`5.0.0` 버전으로 업데이트 하였습니다.

## 👩‍💻 작업 사항

- `swagger-ui-express` 버전 `4.6.3` ➜ **`5.0.0`** 으로 업데이트
- `회원 탈퇴 및 사유 기록` API `400` 에러 확인에 대한 조건문 참 조건 수행문 **소괄호** 제거 및 `swagger-doc` 내용 추가

## ✅ 참고 사항

없습니다
