### PR TITLE
[refactor]: 일부 APIs swagger-doc 리펙토링 (#119)

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -211,24 +211,7 @@ router.post('/public/login', async (req, res) => {
  *       201:
  *         description: Created
  *         schema:
- *           type: object
- *           properties:
- *             _id:
- *               type: string
- *             email:
- *               type: string
- *             password:
- *               type: string
- *             username:
- *               type: string
- *             role:
- *               type: string
- *             point:
- *               type: number
- *             createdTime:
- *               type: string
- *             __v:
- *               type: number
+ *           $ref: '#/definitions/UserInfo'
  *       400:
  *         description: Bad request
  *         schema:

--- a/routes/bookmarks.js
+++ b/routes/bookmarks.js
@@ -417,17 +417,7 @@ router.get(
  *       201:
  *         description: Created
  *         schema:
- *           properties:
- *             _id:
- *               type: string
- *             userId:
- *               type: string
- *             bookmarkName:
- *               type: string
- *             iconColor:
- *               type: string
- *             __v:
- *               type: number
+ *           $ref: '#/definitions/Bookmark'
  *       400:
  *         description: Bad Request
  *         schema:

--- a/routes/headcounts.js
+++ b/routes/headcounts.js
@@ -381,19 +381,7 @@ router.get(
  *       201:
  *         description: Created
  *         schema:
- *           type: object
- *           properties:
- *             _id:
- *               type: string
- *             placeId:
- *               type: string
- *             headcount:
- *               type: number
- *             createdTime:
- *               type: string
- *               example: "2023-07-29 20:44:51.681"
- *             __v:
- *               type: number
+ *           $ref: '#/definitions/Headcount'
  *       400:
  *         description: Bad Request
  *         schema:

--- a/routes/places.js
+++ b/routes/places.js
@@ -92,20 +92,7 @@ const getPlace = async (req, res, next) => {
  *       201:
  *         description: Created
  *         schema:
- *           properties:
- *               properties:
- *                 _id:
- *                   type: string
- *                 placeName:
- *                   type: string
- *                 address:
- *                   type: string
- *                 detailAddress:
- *                   type: string
- *                 markerId:
- *                   type: string
- *                 __v:
- *                   type: number
+ *           $ref: '#/definitions/Place'
  *       400:
  *         description: Bad Request
  *         schema:

--- a/routes/users.js
+++ b/routes/users.js
@@ -167,18 +167,7 @@ router.get('/private/info', verifyToken, getUserInfo, async (req, res) => {
  *       201:
  *         description: Created
  *         schema:
- *           type: object
- *           properties:
- *             _id:
- *               type: string
- *             email:
- *               type: string
- *             username:
- *               type: string
- *             role:
- *               type: string
- *             point:
- *               type: number
+ *           $ref: '#/definitions/UserInfo'
  *       400:
  *         description: Bad Request
  *         schema:
@@ -261,7 +250,7 @@ router.post('/generate-temp-password', async (req, res) => {
                           style="text-decoration: none"
                           ><img
                             src="https://avatars.githubusercontent.com/u/114721330?s=200&v=4"
-                            alt="MUSINSA"
+                            alt="SINABRO"
                             height="50px; border:0;"
                             loading="lazy"
                           />
@@ -396,7 +385,7 @@ router.post('/generate-temp-password', async (req, res) => {
       if (err) {
         return res.status(500).json({ error: err.message });
       } else {
-        return res.status(201).json({ message: newUser });
+        return res.status(201).json(newUser);
       }
     });
   } catch (error) {


### PR DESCRIPTION
## 👀 이슈

resolve #119 

## 📌 개요

프로젝트 내에 `swagger-doc` **definition**으로 정의된 부분을
**`HTTP response body`** 로써 사용하는 APIs에 대하여 해당
definition으로 변경하여 코드의 길이를 축소하였습니다.

## 👩‍💻 작업 사항

- `auth` 라우터 내 **회원 가입** API `swagger-doc` 리팩토링
- `bookmarks` 라우터 내 **신규 즐겨찾기 리스트 등록** API `swagger-doc` 리팩토링
- `headcounts` 라우터 내 **특정 장소에 대한 인원수 등록** API `swagger-doc` 리팩토링
- `places` 라우터 내 **신규 장소 등록** API `swagger-doc` 리팩토링
- `users` 라우터 내 **임시 비밀번호 생성** API `swagger-doc` 리팩토링

## ✅ 참고 사항

없습니다
